### PR TITLE
Checks for test.bat before trying to call it post build

### DIFF
--- a/vHC/HC_Reporting/VeeamHealthCheck.csproj
+++ b/vHC/HC_Reporting/VeeamHealthCheck.csproj
@@ -162,7 +162,11 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="call A:\source\veeam-healthcheck\vHC\HC_Reporting\Tools\build\BuildCopy.bat&#xD;&#xA;&#xA;" />
+	  <Message Text="Checking if test.bat exists: $(ProjectDir)Tools\build\test.bat" Importance="High" />
+	  <ItemGroup>
+		  <LocalPostBuildBat Include="$(ProjectDir)Tools\build\test.bat" Condition="Exists('$(ProjectDir)Tools\build\test.bat')" />
+	  </ItemGroup>
+	  <Exec Command="call @(LocalPostBuildBat)" />
   </Target>
 
   <ItemGroup>

--- a/vHC/HC_Reporting/VeeamHealthCheck.csproj
+++ b/vHC/HC_Reporting/VeeamHealthCheck.csproj
@@ -164,8 +164,10 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
 	  <Message Text="Checking if test.bat exists: $(ProjectDir)Tools\build\test.bat" Importance="High" />
 	  <ItemGroup>
+		  <!-- Sets a local MSBuild variable (maybe wrong word for it) if test.bat exists -->
 		  <LocalPostBuildBat Include="$(ProjectDir)Tools\build\test.bat" Condition="Exists('$(ProjectDir)Tools\build\test.bat')" />
 	  </ItemGroup>
+	  <!-- Calls the bat file, if the variable exists, if not this does nothing and silently continues -->
 	  <Exec Command="call @(LocalPostBuildBat)" />
   </Target>
 


### PR DESCRIPTION
# Checks for test.bat before trying to call it post build

By contributing, you agree that your contributions will be licensed under the projects original open source license.

## Description

These commits add the ability for the build to work on workspaces that do not have test.bat files defined in their workspace. Building will now check if the file exists; if it does, it will call it; otherwise, it will continue silently.

### Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

Since the repo ignores test.bat by default, any fresh clone of the repo and then build will produce an error stating the file cannot be found. 

To test this change, I created a bat file that echoed Hello World, exited with status code 0, and named it test.bat. When building that bat file was executed and showed in the build output. I then renamed the file to something else and rebuilt the health check tool. The result was no error being thrown.

No unit tests for this were written.

### Checklist (check all applicable):

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in _hard to understand_ areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
