### PR TITLE
Implement strict VirusTotal security gate

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1380,16 +1380,20 @@ jobs:
         
         if ($scanId -eq 'skip') {
           if ($reason -eq 'file_too_large') {
-            echo "clean=true" >> $env:GITHUB_OUTPUT
-            echo "⚠️ ZIP scan skipped (file too large for VirusTotal API) - allowing release"
+            echo "clean=false" >> $env:GITHUB_OUTPUT
+            echo "❌ ZIP scan skipped (file too large for VirusTotal API) - blocking release in strict mode"
+            echo "::error title=VirusTotal Scan Required::File too large to scan. Manual review required."
+            exit 1
           } elseif ($reason -eq 'no_api_key') {
-            echo "clean=unknown" >> $env:GITHUB_OUTPUT
-            echo "⚠️ ZIP scan skipped (no API key)"
+            echo "clean=false" >> $env:GITHUB_OUTPUT
+            echo "❌ ZIP scan skipped (no API key) - blocking release in strict mode"
+            echo "::error title=VirusTotal API Key Required::Configure VIRUSTOTAL_API_KEY secret for releases."
+            exit 1
           } else {
-            echo "clean=unknown" >> $env:GITHUB_OUTPUT
-            echo "⚠️ ZIP scan skipped"
+            echo "clean=false" >> $env:GITHUB_OUTPUT
+            echo "❌ ZIP scan skipped - blocking release in strict mode"
+            exit 1
           }
-          exit 0
         }
         
         if ($scanId -eq 'error') {
@@ -1401,25 +1405,20 @@ jobs:
         $malicious = [int]"${{ steps.poll_zip.outputs.malicious }}"
         $suspicious = [int]"${{ steps.poll_zip.outputs.suspicious }}"
         
-        # Allow up to 2 malicious detections (typical for false positives from obscure AVs)
-        if ($malicious -gt 2) {
+        # Strict mode: Block release on ANY detections (including likely false positives)
+        if ($malicious -gt 0) {
           echo "clean=false" >> $env:GITHUB_OUTPUT
           echo "needs_review=true" >> $env:GITHUB_OUTPUT
-          echo "❌ VirusTotal flagged ZIP as malicious ($malicious detections)"
+          echo "❌ VirusTotal flagged ZIP as malicious ($malicious detection(s))"
           echo "📊 Review scan results: $scanUrl"
-          echo "::error title=VirusTotal Detection::ZIP flagged by $malicious engine(s). Review: $scanUrl"
+          echo "::error title=VirusTotal Detection::ZIP flagged by $malicious engine(s). Manual review required: $scanUrl"
           exit 1
-        } elseif ($malicious -gt 0) {
-          echo "clean=warning" >> $env:GITHUB_OUTPUT
-          echo "⚠️ VirusTotal flagged ZIP with $malicious detection(s) - likely false positive"
-          echo "📊 Review scan results: $scanUrl"
-          echo "::warning title=VirusTotal Detection::ZIP flagged by $malicious engine(s). Review: $scanUrl"
-        } elseif ($suspicious -gt 2) {
+        } elseif ($suspicious -gt 0) {
           echo "clean=false" >> $env:GITHUB_OUTPUT
           echo "needs_review=true" >> $env:GITHUB_OUTPUT
-          echo "⚠️ VirusTotal marked ZIP as suspicious ($suspicious detections)"
+          echo "❌ VirusTotal marked ZIP as suspicious ($suspicious detection(s))"
           echo "📊 Review scan results: $scanUrl"
-          echo "::warning title=VirusTotal Suspicious::ZIP flagged as suspicious by $suspicious engine(s). Review: $scanUrl"
+          echo "::error title=VirusTotal Suspicious::ZIP flagged as suspicious by $suspicious engine(s). Manual review required: $scanUrl"
           exit 1
         } else {
           echo "clean=true" >> $env:GITHUB_OUTPUT
@@ -1458,9 +1457,10 @@ jobs:
   create-release:
     needs: [build-and-test, virustotal-scan]
     runs-on: windows-latest
+    # Strict security gate: only create release with zero VirusTotal detections
     if: |
-      github.ref == 'refs/heads/master' && 
-      (needs.virustotal-scan.outputs.zip_clean == 'true' || needs.virustotal-scan.outputs.zip_clean == 'warning' || needs.virustotal-scan.outputs.zip_clean == 'unknown')
+      github.ref == 'refs/heads/master' &&
+      needs.virustotal-scan.outputs.zip_clean == 'true'
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Problem
Current CI workflow allows releases with:
- 1-2 VirusTotal detections (assuming false positives)
- No API key configured (scan skipped)
- Files too large to scan (scan skipped)

This is too permissive for a security tool where users expect zero detections.

## Solution
Implement strict security gate:
- **Only** `clean == 'true'` (zero detections) creates release
- Block on ANY malicious detections
- Block on ANY suspicious detections  
- Block if no VirusTotal API key configured
- Block if file too large to scan

## Trade-offs

**Benefits:**
- Zero-detection standard for security tool
- Forces proper VirusTotal configuration
- Catches false positives before release

**Cost:**
- Legitimate false positives will block automatic release
- Requires manual release workflow for override after review

## Changes
- `create-release` job condition: only `zip_clean == 'true'`
- `evaluate_zip` step: blocks on any detections or scan failures
- All blocked cases show as errors (not warnings)

## Testing
After merge, next master push will:
1. Run VirusTotal scan
2. Block release if ANY detection OR scan unavailable
3. Require manual review + Manual Release workflow for override

🤖 Generated with [Claude Code](https://claude.com/claude-code)