### PR TITLE
Fix artifact upload for integration-test-vbr-13-sql

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -572,7 +572,7 @@ jobs:
       id: find_report
       if: always()
       run: |
-        $reportDir = "C:\temp\vHC\vHC-Report\vHC-Report"
+        $reportDir = "C:\temp\vHC\vHC-Report"
         if (Test-Path $reportDir) {
           $latestReport = Get-ChildItem -Path $reportDir -Filter "*.html" | 
             Sort-Object LastWriteTime -Descending | 


### PR DESCRIPTION
## Problem
The `integration-test-vbr-13-sql` job was skipping the "Upload health check report" step, preventing the HTML report from being available as an artifact for review.

## Root Cause
The "Find generated report" step was looking in an incorrect nested directory:
```
C:\temp\vHC\vHC-Report\vHC-Report  (nested - incorrect)
```

While the other two integration tests (`integration-test-vbr` and `integration-test-vbr-12`) correctly use:
```
C:\temp\vHC\vHC-Report  (single-level - correct)
```

This path mismatch caused the find step to not locate the report, which prevented the `report_path` output from being set, which in turn caused the upload step to be skipped due to the conditional:
```yaml
if: always() && steps.find_report.outputs.report_path
```

## Solution
Changed line 575 in `.github/workflows/ci-cd.yaml` to use the correct single-level path, matching the other integration tests.

## Changes
- **File:** `.github/workflows/ci-cd.yaml`
- **Line:** 575
- **Change:** Removed extra nested `vHC-Report` directory from path

## Testing
After this change, all three integration tests will consistently upload their health check report artifacts for review.

## Verification
Confirmed all three integration test jobs now use identical paths:
- Line 207 (vbr): `C:\temp\vHC\vHC-Report` ✅
- Line 575 (vbr-13-sql): `C:\temp\vHC\vHC-Report` ✅ (fixed)
- Line 942 (vbr-12): `C:\temp\vHC\vHC-Report` ✅