### PR TITLE
docs: add GitHub Pages site with MkDocs Material and auto-deploy CI

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,103 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "ChangeLog.md"
+      - "requirements-docs.txt"
+  workflow_dispatch:
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+env:
+  REPO_URL: https://github.com/VeeamHub/veeam-healthcheck
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install MkDocs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Sync changelog from ChangeLog.md
+        run: |
+          { printf '# Changelog\n\n> This page is auto-synced from [ChangeLog.md](${{ env.REPO_URL }}/blob/master/ChangeLog.md) on every push to `master`.\n\n'; cat ChangeLog.md; } > docs/changelog.md
+
+      - name: Generate feature timeline from git log
+        run: |
+          python3 - <<'EOF'
+          import subprocess
+          import re
+          import os
+          from collections import defaultdict
+
+          repo_url = os.environ["REPO_URL"]
+
+          result = subprocess.run(
+              ["git", "log", "--pretty=format:%H|%ai|%s", "--no-merges"],
+              capture_output=True,
+              text=True,
+          )
+
+          entries_by_month = defaultdict(list)
+          feat_pattern = re.compile(r"^feat(?:\(.*?\))?:\s*(.+)$", re.IGNORECASE)
+
+          for line in result.stdout.splitlines():
+              parts = line.split("|", 2)
+              if len(parts) != 3:
+                  continue
+              sha, date_str, subject = parts
+              month = date_str[:7]
+              m = feat_pattern.match(subject.strip())
+              if m:
+                  description = m.group(1).strip()
+                  entries_by_month[month].append((sha[:7], description))
+
+          lines = ["# Feature Timeline", ""]
+          lines.append("> Auto-generated from `feat:` commits. Updated on every push to `master`.")
+          lines.append("")
+
+          if not entries_by_month:
+              lines.append("*No feature commits found yet.*")
+          else:
+              for month in sorted(entries_by_month.keys(), reverse=True):
+                  lines.append(f"## {month}")
+                  lines.append("")
+                  for short_sha, desc in entries_by_month[month]:
+                      commit_url = f"{repo_url}/commit/{short_sha}"
+                      lines.append(f"- [{desc}]({commit_url})")
+                  lines.append("")
+
+          with open("docs/timeline.md", "w", encoding="utf-8") as f:
+              f.write("\n".join(lines))
+
+          total = sum(len(v) for v in entries_by_month.values())
+          print(f"Generated timeline: {total} features across {len(entries_by_month)} months")
+          EOF
+        env:
+          REPO_URL: ${{ env.REPO_URL }}
+
+      - name: Build and deploy to GitHub Pages
+        run: mkdocs gh-deploy --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -386,7 +386,7 @@ mempalace.yaml
 Plans/
 vHC/Plans/
 .playwright-mcp/
-docs/
+docs/MONITOR_NATIVE_ARCHITECTURE.md
 entities.json
 mempalace.yaml
 MEMORY/

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@
   <a href="https://github.com/VeeamHub/veeam-healthcheck/releases/latest"><img src="https://img.shields.io/github/v/release/VeeamHub/veeam-healthcheck?label=Latest%20Release" alt="Latest Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/VeeamHub/veeam-healthcheck" alt="License: MIT"></a>
   <img src="https://img.shields.io/badge/.NET-8.0-blue" alt=".NET 8.0">
+  <a href="https://veeamhub.github.io/veeam-healthcheck/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-green" alt="Documentation"></a>
 </p>
 
 <p align="center">
   <a href="https://github.com/VeeamHub/veeam-healthcheck/releases/latest"><strong>Download Latest Release</strong></a> &nbsp;&middot;&nbsp;
   <a href="https://htmlpreview.github.io/?https://github.com/VeeamHub/veeam-healthcheck/blob/master/SAMPLE/Veeam%20Health%20Check%20Report_VBR_anon_2024.11.01.101304.html"><strong>View Sample Report</strong></a> &nbsp;&middot;&nbsp;
+  <a href="https://veeamhub.github.io/veeam-healthcheck/"><strong>Documentation</strong></a> &nbsp;&middot;&nbsp;
   <a href="https://github.com/VeeamHub/veeam-healthcheck/issues/new/choose"><strong>Report an Issue</strong></a>
 </p>
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,0 +1,71 @@
+# Architecture
+
+## Three-Phase Pipeline
+
+```
+Collection → Processing/Analysis → Report Generation
+```
+
+| Phase | What Happens |
+|---|---|
+| **Collection** | PowerShell scripts, SQL queries, registry reads, log parsing, WMI — outputs CSV files |
+| **Processing** | CSV parsing, data transformation, typing via `CDataFormer` |
+| **Report Generation** | HTML compiler renders typed objects into the single-page report |
+
+## Key Components
+
+### Entry Point & Flow
+
+| Component | File | Role |
+|---|---|---|
+| `EntryPoint` | `Startup/EntryPoint.cs` | Main entry, handles single-file deployment |
+| `CArgsParser` | `Startup/CArgsParser.cs` | CLI argument parsing, routes to GUI or CLI mode |
+| `VhcGui` | `Startup/VhcGui.xaml.cs` | WPF GUI for interactive use |
+| `CGlobals` | `Common/CGlobals.cs` | Central static configuration — all execution flags and shared state |
+
+### Data Collection
+
+- Multi-source: PowerShell scripts, SQL, registry, log parsing, WMI
+- PowerShell scripts live in `Tools/Scripts/HealthCheck/VBR/` and `Tools/Scripts/HealthCheck/VB365/`
+- Output: CSV files to `C:\temp\vHC\Original\{VBR|VB365}\{servername}\{timestamp}\`
+
+### Report Generation
+
+| Component | File | Role |
+|---|---|---|
+| `CHtmlCompiler` | `Reporting/Html/VBR/CHtmlCompiler.cs` | VBR report compiler |
+| `CVb365HtmlCompiler` | `Reporting/Html/VB365/CVb365HtmlCompiler.cs` | VB365 report compiler |
+| `CReportModeSelector` | `Reporting/CReportModeSelector.cs` | Routes to correct compiler based on detected product |
+
+### Data Processing
+
+| Component | Role |
+|---|---|
+| `CCsvReader` | CSV reading via CsvHelper |
+| `CCsvParser` | Static methods returning dynamic objects for flexible CSV parsing |
+| `CDataFormer` | Transforms raw data into typed report objects |
+
+## VBR vs VB365 Detection
+
+Product detection in `CClientFunctions.ModeCheck()` by scanning running processes:
+
+- `Veeam.Backup.Service` → VBR mode
+- `Veeam.Archiver.Service` → VB365 mode
+
+Each product has separate collection scripts, HTML compilers, and table renderers.
+
+## Tech Stack
+
+| Technology | Usage |
+|---|---|
+| **.NET 8.0** | Windows 7.0+ target |
+| **WPF** | GUI |
+| **PowerShell 7 SDK** | Embedded script execution |
+| **CsvHelper** | CSV processing |
+| **DinkToPdf** | PDF export |
+| **DocumentFormat.OpenXml + HtmlToOpenXml** | PowerPoint export |
+| **xUnit + Moq** | Testing |
+
+## Architecture Decision Records
+
+ADRs track non-obvious design decisions. See the [`docs/adr/`](../adr/) folder for the full record.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+> This page is auto-synced from [ChangeLog.md](https://github.com/VeeamHub/veeam-healthcheck/blob/master/ChangeLog.md) on every push to `master`.
+
+*Content will appear after first CI run.*

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,43 @@
+# Contributing
+
+We welcome contributions — bug reports, fixes, new features, and documentation improvements.
+
+## How to Contribute
+
+All contributions to this repository must be signed as described in the [Developer Certificate of Origin](https://github.com/VeeamHub/veeam-healthcheck/blob/master/DCO.md). Your signature certifies that you wrote the contribution or have the right to pass it on as an open source contribution.
+
+### Report a Bug or Request a Feature
+
+[Open a new issue](https://github.com/VeeamHub/veeam-healthcheck/issues/new/choose) — it's that easy.
+
+### Submit a Fix or Feature
+
+1. Fork the repository
+2. Create a feature branch from `master`
+3. Write your change with tests where applicable
+4. Follow the [test naming convention](architecture/index.md#testing): `[MethodUnderTest]_[Scenario]_[ExpectedBehavior]`
+5. Open a pull request against `master`
+
+## Development Setup
+
+```bash
+# Restore dependencies
+dotnet restore vHC/HC.sln
+
+# Build (debug)
+dotnet build vHC/HC.sln --configuration Debug
+
+# Run tests (Windows only — requires WPF/.NET Windows)
+dotnet test vHC/VhcXTests/VhcXTests.csproj
+```
+
+!!! note
+    Tests require Windows due to WPF dependencies. Non-Windows builds skip test compilation.
+
+## Commit Convention
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) — `feat:`, `fix:`, `chore:`, `ci:`, `test:`, `docs:`. Feature commits (`feat:`) appear in the auto-generated [Feature Timeline](timeline.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's [MIT License](https://github.com/VeeamHub/veeam-healthcheck/blob/master/LICENSE).

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,70 @@
+# Features
+
+## Report Sections
+
+### VBR (Veeam Backup & Replication)
+
+| Section | Description |
+|---|---|
+| **Job Session Analytics** | Min/max/average for duration, backup size, data size, and wait times per job |
+| **Success & Change Rates** | Environment-wide visibility — success rate, change rate by job |
+| **Concurrency Heat Maps** | Job and task overlap visualized over time |
+| **Managed Server Table** | All registered servers with platform identification (Proxmox, Nutanix AHV, etc.) |
+| **Job Info Table** | Per-job configuration with platform, policy, and sizing data |
+| **License & Auto-Update** | License expiry, edition, and auto-update status |
+| **Repository Summary** | Capacity, free space, immutability, and dedup/compression settings |
+| **Proxy Configuration** | Proxy count, type, sizing, and task capacity |
+| **Configuration Review** | Best-practice flags highlighting areas needing attention |
+| **Curated Guidance** | Recommendations with links to Veeam documentation |
+
+### VB365 (Veeam Backup for Microsoft 365)
+
+| Section | Description |
+|---|---|
+| **Organization Summary** | Protected users, groups, sites, and teams |
+| **Job Configuration** | Schedule, retention, and policy overview |
+| **Repository Health** | Capacity and utilization per repository |
+
+## Export Formats
+
+| Format | Notes |
+|---|---|
+| **HTML** | Default — single file, embedded CSS/JS, works offline |
+| **PDF** | Via DinkToPdf, print-ready |
+| **PowerPoint** | Via HtmlToOpenXml, editable slide deck |
+| **Scrubbed** | Any format with IPs, server names, and credentials anonymized |
+
+## Execution Modes
+
+| Mode | Flag | Use Case |
+|---|---|---|
+| **GUI** | `/gui` | Interactive, guided configuration |
+| **CLI** | `/run` | Scripted, automated, unattended |
+| **Silent** | `/run /silent` | Fleet automation, no prompts |
+| **Remote** | `/run /host=<name>` | Run from a jump host against a remote VBR server |
+| **Security** | `/security` | Security-focused assessment only |
+| **Import** | `/import` | Generate report from pre-collected CSV data |
+
+## Platform Coverage
+
+Veeam Health Check detects and reports on managed server platform types:
+
+- Proxmox VE
+- Nutanix AHV
+- HPE Morpheus VME
+- Scale Computing HyperCore
+- XCP-ng
+- Sangfor HCI
+- Red Hat Virtualization
+- Kasten
+- Standard VMware/Hyper-V
+
+## Silent / Unattended Mode
+
+Added in May 2026. Enables fleet-wide automation with no interactive prompts.
+
+```powershell
+VeeamHealthCheck.exe /run /silent /days:30 /outdir=\\nas\reports\$env:COMPUTERNAME /pdf
+```
+
+Exit codes are documented in the help menu (`/help`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,93 @@
+# Getting Started
+
+## Requirements
+
+- Windows system with **VBR Console** or **VB365** installed
+- Run as an **elevated user** with **Backup Administrator** role
+- **500 MB** free disk space on `C:\` (default output: `C:\temp\vHC`)
+- Veeam Cloud Service Provider servers are **not** supported
+
+## Supported Versions
+
+| Product | Supported Versions | Notes |
+|---|---|---|
+| **Veeam Backup & Replication** | v12.3, v13 (Windows & Linux) | For v11/v12 pre-12.3, use [Health Check v2](https://github.com/VeeamHub/veeam-healthcheck/releases/tag/v2.0.0.681) |
+| **Veeam Backup for Microsoft 365** | v6, v7, v8 | |
+
+## Installation
+
+1. **[Download](https://github.com/VeeamHub/veeam-healthcheck/releases/latest)** the latest `VeeamHealthCheck.zip`
+2. **Extract** the archive on your Veeam server
+3. **Run** `VeeamHealthCheck.exe` as Administrator
+
+No installer. No dependencies to install. Single executable.
+
+## Running a Health Check
+
+=== "GUI"
+    1. Launch `VeeamHealthCheck.exe` as Administrator
+    2. Configure options (reporting window, export format, output path)
+    3. Accept the terms and click **RUN**
+    4. Review the generated report
+
+=== "CLI"
+    ```powershell
+    # Standard health check (7-day window)
+    VeeamHealthCheck.exe /run
+
+    # 30-day window, also export PDF
+    VeeamHealthCheck.exe /run /days:30 /pdf
+
+    # Custom output directory, open report when done
+    VeeamHealthCheck.exe /run /outdir=D:\Reports /show:report
+    ```
+
+## CLI Reference
+
+```
+VeeamHealthCheck.exe [options]
+```
+
+| Option | Description |
+|---|---|
+| `/run` | Execute health check via CLI |
+| `/gui` | Launch graphical interface |
+| `/help` | Show full help menu |
+| `/days:<N>` | Reporting window: 7, 12, 30, or 90 days (default: 7) |
+| `/outdir=<path>` | Output directory (default: `C:\temp\vHC`) |
+| `/pdf` | Also export as PDF |
+| `/pptx` | Also export as PowerPoint |
+| `/scrub:true` | Anonymize sensitive data |
+| `/lite` | Skip per-job HTML exports (faster) |
+| `/show:report` | Open report in browser when done |
+| `/show:files` | Open output folder in Explorer |
+| `/remote` | Enable remote execution |
+| `/host=<hostname>` | Target remote Veeam server |
+| `/security` | Run security-focused assessment only |
+| `/import[:<path>]` | Generate report from existing CSV data |
+| `/clearcreds` | Clear stored credentials |
+| `/debug` | Enable debug logging |
+
+## Remote Execution
+
+Run against a remote Veeam server without being locally logged into it:
+
+```powershell
+VeeamHealthCheck.exe /run /host=vbrserver.veeam.local
+```
+
+Credentials are prompted and stored securely in Windows Credential Manager.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---|---|
+| **"Access Denied"** | Run as Administrator with Backup Administrator role |
+| **"No Veeam installation detected"** | Tool must run on a system with VBR Console or VB365 installed |
+| **Low disk space errors** | Ensure `C:\` has at least 500 MB free |
+| **PowerShell errors** | Verify PowerShell 7+ is installed |
+| **Credentials not working** | Run `/clearcreds` then re-authenticate |
+
+## Sample Report
+
+[View a sample anonymized report](https://htmlpreview.github.io/?https://github.com/VeeamHub/veeam-healthcheck/blob/master/SAMPLE/Veeam%20Health%20Check%20Report_VBR_anon_2024.11.01.101304.html) to see what output looks like before running.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,40 @@
+# Veeam Health Check
+
+**Generate comprehensive configuration reports for your Veeam environment in minutes.**
+
+<div style="text-align: center;">
+  <img src="images/health-check-icon.png" alt="Veeam Health Check" width="80">
+</div>
+
+---
+
+!!! note "Community Tool"
+    This is a community-supported tool from [VeeamHub](https://github.com/VeeamHub) and is not an officially supported Veeam product. It does not phone home or communicate with anything beyond your Veeam infrastructure components.
+
+## What It Does
+
+Veeam Health Check is a lightweight Windows utility that analyzes your **Veeam Backup & Replication (VBR)** or **Veeam Backup for Microsoft 365 (VB365)** installation and produces a detailed, single-page HTML report covering:
+
+| Area | Details |
+|------|---------|
+| **Job Session Analytics** | Min/max/average for duration, backup size, data size, and wait times |
+| **Success & Change Rates** | Environment-wide visibility across all jobs |
+| **Concurrency Heat Maps** | Job and task overlap visualized over time |
+| **Configuration Review** | Highlights areas for potential improvement |
+| **Curated Guidance** | Best practices, recommendations, and links to relevant documentation |
+
+## Export Formats
+
+- **HTML** — single-file report with embedded CSS and JavaScript
+- **PDF** — via DinkToPdf
+- **PowerPoint** — via HtmlToOpenXml
+- **Scrubbed Mode** — anonymizes IPs, server names, and credentials before sharing
+
+## Quick Links
+
+- [Getting Started](getting-started.md) — download, install, and run
+- [Features](features.md) — full feature list
+- [Changelog](changelog.md) — release history
+- [Feature Timeline](timeline.md) — auto-generated from git history
+- [Architecture](architecture/index.md) — technical design
+- [GitHub](https://github.com/VeeamHub/veeam-healthcheck) — source code and releases

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -1,0 +1,5 @@
+# Feature Timeline
+
+> Auto-generated from `feat:` commits. Updated on every push to `master`.
+
+*Timeline will appear after first CI run.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: Veeam Health Check
+site_description: Generate comprehensive configuration reports for your Veeam environment in minutes.
+site_url: https://veeamhub.github.io/veeam-healthcheck/
+repo_url: https://github.com/VeeamHub/veeam-healthcheck
+repo_name: VeeamHub/veeam-healthcheck
+edit_uri: edit/master/docs/
+
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: green
+      accent: light green
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: green
+      accent: light green
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  logo: images/health-check-icon.png
+  favicon: images/health-check-icon.png
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Features: features.md
+  - Changelog: changelog.md
+  - Feature Timeline: timeline.md
+  - Architecture: architecture/index.md
+  - Contributing: contributing.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs-material==9.5.25
+mkdocs==1.6.0


### PR DESCRIPTION
## Summary

- Scaffolds a full [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) documentation site at `https://veeamhub.github.io/veeam-healthcheck/`
- Adds a GitHub Actions workflow (`docs-deploy.yml`) that auto-deploys on every push to `master` touching docs-related files
- Workflow auto-syncs `ChangeLog.md` → `docs/changelog.md` and generates a feature timeline from `feat:` commits in git history

## Pages added

| Page | Content |
|---|---|
| `docs/index.md` | Site home with feature overview |
| `docs/getting-started.md` | Download/install/run guide + full CLI reference |
| `docs/features.md` | Feature matrix (VBR, VB365, export formats, platforms) |
| `docs/changelog.md` | Auto-synced from `ChangeLog.md` by CI |
| `docs/timeline.md` | Auto-generated from `feat:` commits by CI |
| `docs/architecture/index.md` | Pipeline, components, tech stack overview |
| `docs/contributing.md` | How to contribute + commit conventions |

## CI workflow behavior

Triggers on push to `master` when any of these change: `docs/**`, `mkdocs.yml`, `ChangeLog.md`, `requirements-docs.txt`. Has a `concurrency` block to cancel stale in-progress deploys.

## After merging

Go to **Settings → Pages** and set the source branch to `gh-pages` (created automatically on first CI run).

## Test plan

- [ ] Merge triggers `docs-deploy` workflow in Actions
- [ ] Workflow completes and creates `gh-pages` branch
- [ ] Set Pages source to `gh-pages` in repo settings
- [ ] `https://veeamhub.github.io/veeam-healthcheck/` loads the site
- [ ] Feature timeline shows `feat:` commits grouped by month
- [ ] Changelog shows content from `ChangeLog.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)