### PR TITLE
fix(ci): add cache-dependency-path for docs deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
+          cache-dependency-path: requirements-docs.txt
 
       - name: Install MkDocs dependencies
         run: pip install -r requirements-docs.txt


### PR DESCRIPTION
## Summary

- `actions/setup-python@v5` with `cache: "pip"` looks for `requirements.txt` by default
- Our file is named `requirements-docs.txt` — the cache step errored and blocked the deploy
- One-line fix: add `cache-dependency-path: requirements-docs.txt`

## Test plan

- [ ] Merge triggers `docs-deploy` workflow
- [ ] Workflow completes successfully
- [ ] `gh-pages` branch appears in repo
- [ ] Set Pages source to `gh-pages` in Settings → Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)