### PR TITLE
fix(security): scrub email From/To addresses in scrub mode (CWE-359)

### DIFF
--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
@@ -47,13 +47,19 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
                         s += "<tr>";
 
                         string smtpServer = (string)(item.smtpserver ?? "");
+                        string fromAddr = (string)(item.from ?? "");
+                        string toAddr = (string)(item.to ?? "");
                         if (scrub)
+                        {
                             smtpServer = CGlobals.Scrubber.ScrubItem(smtpServer, ScrubItemType.Server);
+                            fromAddr = CGlobals.Scrubber.ScrubItem(fromAddr, ScrubItemType.Item);
+                            toAddr = CGlobals.Scrubber.ScrubItem(toAddr, ScrubItemType.Item);
+                        }
 
                         s += this.form.TableData((string)(item.isenabled ?? ""), string.Empty);
                         s += this.form.TableData(smtpServer, string.Empty);
-                        s += this.form.TableData((string)(item.from ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.to ?? ""), string.Empty);
+                        s += this.form.TableData(fromAddr, string.Empty);
+                        s += this.form.TableData(toAddr, string.Empty);
                         s += this.form.TableData((string)(item.notifyonsuccess ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.notifyonwarning ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.notifyonerror ?? ""), string.Empty);


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #4 — `cs/exposure-of-sensitive-information` (CWE-359).

`CEmailNotificationTable` was already scrubbing the SMTP server field when scrub mode is enabled, but the `From` and `To` email addresses were written to the report file unscrubbed. Both are PII and should be treated the same as the server field.

## Change

In `CEmailNotificationTable.cs`, applied `CGlobals.Scrubber.ScrubItem()` to `from` and `to` fields when `scrub=true`, consistent with the existing `smtpServer` scrub pattern. Both use `ScrubItemType.Item` (generic anonymized token, e.g. `Item_0`).

## Test plan

- [ ] Build passes
- [ ] With `/scrub:true`: From/To addresses replaced with `Item_N` tokens in report
- [ ] Without `/scrub:true`: From/To addresses render as-is (no behavior change)
- [ ] CodeQL re-scan clears alert #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)