### PR TITLE
docs: clarify PR branching policy (target dev, not master)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,11 @@
 # Pull Request Template
 
+> [!IMPORTANT]
+> **All pull requests must target the `dev` branch, not `master`.**
+> `master` is the release branch; changes flow `dev` → `master` via release PRs only.
+> If you opened this PR against `master` by mistake, change the base branch to `dev` in the dropdown above (no need to close and reopen).
+> See [CONTRIBUTING.md → Branching strategy](../blob/dev/CONTRIBUTING.md#branching-strategy) for details.
+
 By contributing, you agree that your contributions will be licensed under the projects original open source license.
 
 ## Description

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,24 @@ Please note we have a [Code of Conduct](#code-of-conduct). Please follow it in a
 
 We use GitHub's Issue Tracker to track bugs/feature Requests. Report a bug or feature request by [opening a new issue](https://github.com/VeeamHub/{repo-name}/issues/new/choose). It's that easy!
 
+## Branching strategy
+
+This repository uses a `dev` → `master` release flow:
+
+- **`master`** — release branch. Protected. Updated only by maintainers via release PRs from `dev`. Do not open PRs directly against `master`.
+- **`dev`** — integration branch. **All contributor PRs target `dev`.**
+- **Feature branches** — branch off `dev`, open your PR back into `dev`.
+
+To target `dev` from the command line:
+
+```sh
+gh pr create --base dev --title "..." --body "..."
+```
+
+If you accidentally opened a PR against `master`, you can change the base branch to `dev` in the GitHub UI ("Edit" next to the title → change base) — no need to close and reopen. Maintainers may also retarget your PR for you.
+
+PRs to `master` will appear stuck (mergeability "blocked") because `master`'s required `build-and-test` check only runs on push events, not on PRs. Targeting `dev` avoids this entirely.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the projects original open source license.


### PR DESCRIPTION
## Summary
- Add a top-of-template IMPORTANT callout in `.github/pull_request_template.md` telling contributors to target `dev`, not `master`.
- Add a new "Branching strategy" section to `CONTRIBUTING.md` documenting the `dev` → `master` release flow.
- Explain *why* PRs to `master` appear stuck (the required `build-and-test` check in `ci-cd.yaml` only fires on `push:` events, not on PRs), so contributors who hit it understand the gotcha.

## Motivation
PR #136 was opened against `master` and stayed in `BLOCKED` state because the required `build-and-test` check never runs on PRs. The PR template and `CONTRIBUTING.md` did not mention the branching policy, so the mistake is on the docs, not the contributor. Retargeting PR #136 to `dev` unblocked it; this PR closes the docs gap so future contributors don't repeat it.

## Test plan
- [ ] Render `pull_request_template.md` in a draft PR to confirm the `[!IMPORTANT]` callout displays correctly.
- [ ] Verify the link from the PR template to `CONTRIBUTING.md#branching-strategy` resolves on `dev` after merge.
- [ ] Confirm no behavioral / workflow changes (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)