### PR TITLE
fix(scripts): guard Get-NasInfo against missing VMC.log

### DIFF
--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1
@@ -1,0 +1,78 @@
+#Requires -Version 7.0
+# Pester v5 tests for Get-NasInfo.ps1 VMC.log existence guard (ISC-1..5)
+
+BeforeAll {
+    $script:ScriptPath = Join-Path $PSScriptRoot 'Get-NasInfo.ps1'
+}
+
+Describe 'Get-NasInfo VMC.log existence guard' {
+
+    BeforeEach {
+        $script:TempPath = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString())
+        New-Item -Path $script:TempPath -ItemType Directory -Force | Out-Null
+    }
+
+    AfterEach {
+        if (Test-Path -LiteralPath $script:TempPath) {
+            Remove-Item -LiteralPath $script:TempPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context 'ISC-3/4: when VMC.log is absent' {
+
+        It 'exits with no error and invokes Get-Content zero times for the VMC.log path' {
+            # Default Test-Path mock returns true (covers ReportPath existence check on line 97)
+            Mock Test-Path -MockWith { $true }
+            # Specific override: VMC.log path (LiteralPath) returns false
+            Mock Test-Path -MockWith { $false } -ParameterFilter {
+                $LiteralPath -eq 'C:\ProgramData\Veeam\Backup\Utils\VMC.log'
+            }
+            # Get-Content should never be called for the VMC.log path — no ParameterFilter so
+            # any call (positional or named) is counted. Before the fix the script calls
+            # Get-Content $logsPath unconditionally; after the fix with path absent it is skipped.
+            Mock Get-Content -MockWith { @() }
+            # Export-Csv: suppress actual file writes for this test
+            Mock Export-Csv -MockWith { }
+            # New-Item: suppress directory creation side effects
+            Mock New-Item -MockWith { }
+
+            { & $script:ScriptPath -VBRServer 'TESTSRV' -VBRVersion 12 -ReportPath $script:TempPath } |
+                Should -Not -Throw
+
+            # ISC-4: Get-Content must be called 0 times total (no guard = called once, fails RED)
+            Should -Invoke Get-Content -Times 0 -Exactly
+        }
+    }
+
+    Context 'ISC-5: happy path - VMC.log present with NAS INFRASTRUCTURE block' {
+
+        It 'writes a non-empty NasFileData CSV when VMC.log contains a valid NAS block' {
+            # All Test-Path calls return true (VMC.log exists, ReportPath exists)
+            Mock Test-Path -MockWith { $true }
+
+            # Fixture: one =====NAS INFRASTRUCTURE==== block ending with ========
+            # Lines must be >= 49 chars so .Remove(0,49) strips the timestamp prefix.
+            # After stripping, the line must match "NasBackupSourceShareStats" and contain
+            # at least one "key: value" pair for Export-Csv to produce a row.
+            # Prefix is 49 chars: "2024-01-15 08:30:00.123 [Info] VmcStatMgr.cs 123 "
+            $prefix = 'A' * 49
+            Mock Get-Content -MockWith {
+                @(
+                    ($prefix + '=====NAS INFRASTRUCTURE===='),
+                    ($prefix + 'NasBackupSourceShareStats: Name: share1, SizeGb: 10'),
+                    ($prefix + '========')
+                )
+            } -ParameterFilter {
+                $LiteralPath -eq 'C:\ProgramData\Veeam\Backup\Utils\VMC.log'
+            }
+
+            & $script:ScriptPath -VBRServer 'TESTSRV' -VBRVersion 12 -ReportPath $script:TempPath
+
+            $csv = Join-Path $script:TempPath 'TESTSRV_NasFileData.csv'
+            (Test-Path -LiteralPath $csv) | Should -BeTrue
+            # Wrap in @() because Get-Content returns a scalar for single-line files in PS 5.x and 7.x;
+            # require header + at least one data row, not just header.
+            @(Get-Content -LiteralPath $csv).Count | Should -BeGreaterThan 1
+        }
+    }
+}

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
@@ -26,7 +26,12 @@ if ([string]::IsNullOrEmpty($ReportPath)) {
  $csv2FilePath = 'output2.csv'
  
  #get file info and set empty containers.
- $content = Get-Content $logsPath
+ if (Test-Path -LiteralPath $logsPath) {
+     $content = Get-Content -LiteralPath $logsPath
+ } else {
+     Write-Verbose "VMC.log not found at $logsPath - skipping unstructured/NAS section parsing"
+     $content = @()
+ }
  $sections = @()
  $currentSection = @()
  $capturing = $false


### PR DESCRIPTION
## Summary
- Wraps `Get-Content` at `Get-NasInfo.ps1:29` in a `Test-Path -LiteralPath` guard; falls through to `$content = @()` + a `Write-Verbose` hint when `C:\ProgramData\Veeam\Backup\Utils\VMC.log` is absent.
- Matches the existing graceful fallback already present on the C# side at `CHtmlTables.cs:660-699`. PS side was the only fragile spot.
- Replaces a 9-line `PowerShell Errors:` stderr dump that pollutes `Job.HealthCheck*.log` on hosts without VMC.log.
- New Pester test file (`Get-NasInfo.Tests.ps1`) covering absent (ISC-3/4) and happy-path (ISC-5) cases. 2/2 pass on macOS Pester 5.7.

## Customer signal
This was the F4 issue surfaced by the customer's 2026-05-12 v3.0.1.148 run, missed in the original diagnosis (we found it during retrospective verification of #138). See `Plans/dreamy-greeting-tome.md` in the repo for the full trail.

## Pipeline used
Architect (10 ISC, 1 file change) → Engineer (TDD red/green captured) → /simplify (3 reviewers; one CSV-row-count assertion strengthened from `>0` to `>1`) → QATester (10/10 ISC PASS).

## Test plan
- [x] Pester `Get-NasInfo.Tests.ps1` 2/2 green locally on macOS (pwsh 7 + Pester 5.7.1)
- [x] PS5.1 compatibility — no ternary, no `??`, no `||`/`&&`, ASCII only (Architect ISC-8)
- [x] Diff is surgical: only line 29 expanded into a 5-line block; param block and `$logsPath` literal unchanged (Architect ISC-6/7)
- [x] C# fallback contract preserved — `CHtmlTables.cs:660-699` handles empty CSV the same as before
- [ ] Windows CI: confirm `PowerShell51CompatibilityTests` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)