### PR TITLE
fix(ci): unblock PR #140 (em-dashes, manifest test, Get-VBRJob stub)

### DIFF
--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Get-NasInfo VMC.log existence guard' {
             Mock Test-Path -MockWith { $false } -ParameterFilter {
                 $LiteralPath -eq 'C:\ProgramData\Veeam\Backup\Utils\VMC.log'
             }
-            # Get-Content should never be called for the VMC.log path — no ParameterFilter so
+            # Get-Content should never be called for the VMC.log path - no ParameterFilter so
             # any call (positional or named) is counted. Before the fix the script calls
             # Get-Content $logsPath unconditionally; after the fix with path absent it is skipped.
             Mock Get-Content -MockWith { @() }

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcBackupSessions.Tests.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcBackupSessions.Tests.ps1
@@ -3,7 +3,7 @@
 #
 # Retrospective TDD for commit 59e2621 on dev.
 # All Veeam SDK cmdlets are stubbed as global no-ops so the suite runs on macOS
-# without a VBR installation — same pattern used in TestMfa.Tests.ps1.
+# without a VBR installation - same pattern used in TestMfa.Tests.ps1.
 #
 # Red-phase strategy:
 #   ISC-2: temporarily revert to single-call pattern in production code.
@@ -166,14 +166,14 @@ Describe 'ISC-3: Mid-iteration throw logs WARNING with job name and message, doe
 
     It 'still returns sessions from the non-failing jobs' {
         $result = @(Get-VhcBackupSessions -ReportInterval 7)
-        # GoodJob and GoodJob2 each return 1 session; BadJob throws — so we expect 2
+        # GoodJob and GoodJob2 each return 1 session; BadJob throws - so we expect 2
         ($result | Where-Object { $_.JobName -eq 'GoodJob'  }).Count | Should -Be 1
         ($result | Where-Object { $_.JobName -eq 'GoodJob2' }).Count | Should -Be 1
     }
 }
 
 # ---------------------------------------------------------------------------
-# ISC-4  Cutoff filter — older sessions excluded, newer included
+# ISC-4  Cutoff filter - older sessions excluded, newer included
 # ---------------------------------------------------------------------------
 Describe 'ISC-4: Cutoff filter excludes sessions older than ReportInterval' {
 
@@ -277,7 +277,7 @@ Describe 'ISC-6: Agent block runs exactly once; agent sessions concatenated with
 }
 
 # ---------------------------------------------------------------------------
-# ISC-7  Return shape — flat array, not nested ArrayList
+# ISC-7  Return shape - flat array, not nested ArrayList
 # ---------------------------------------------------------------------------
 Describe 'ISC-7: Return value is a flat [object[]], not a nested ArrayList' {
 
@@ -304,7 +304,7 @@ Describe 'ISC-7: Return value is a flat [object[]], not a nested ArrayList' {
         $result.GetType().Name | Should -Be 'Object[]'
     }
 
-    It 'returns a flat (non-nested) array — no element is itself an array or ArrayList' {
+    It 'returns a flat (non-nested) array - no element is itself an array or ArrayList' {
         $result = @(Get-VhcBackupSessions -ReportInterval 7)
         foreach ($item in $result) {
             $item | Should -Not -BeOfType [System.Collections.ArrayList]

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/vHC-VbrConfig.Manifest.Tests.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/vHC-VbrConfig.Manifest.Tests.ps1
@@ -27,7 +27,7 @@ BeforeAll {
     $script:Manifest   = Import-PowerShellDataFile -Path $script:PsdPath
 
     # Enumerate Public function names (file base names without .ps1 extension).
-    # Exclude *.Tests.ps1 files — they live in Public/ alongside the functions but
+    # Exclude *.Tests.ps1 files - they live in Public/ alongside the functions but
     # are not module members and should not appear in FunctionsToExport.
     $script:PublicFiles = @(Get-ChildItem -Path $script:PublicPath -Filter '*.ps1' -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -notlike '*.Tests.ps1' } |

--- a/vHC/VhcXTests/Integration/VhcModuleUnitTests.cs
+++ b/vHC/VhcXTests/Integration/VhcModuleUnitTests.cs
@@ -692,7 +692,10 @@ $script:LogPath  = '{tmpDir}'
 $script:LogLevel = 'ERROR'
 
 # Stub VBR cmdlets - no Veeam install required.
-# Get-VBRBackupSession returns empty; Get-VBRComputerBackupJobSession returns one agent session.
+# Get-VBRJob returns empty (no VM/Copy jobs to iterate); Get-VBRBackupSession is
+# therefore never called via -Job; Get-VBRComputerBackupJobSession returns one
+# agent session so the assertion below validates the agent-session fallback path.
+function Get-VBRJob {{ return @() }}
 function Get-VBRBackupSession {{ return @() }}
 function Get-VBRComputerBackupJobSession {{
     return @([pscustomobject]@{{ Name = 'Agent Job'; CreationTime = (Get-Date) }})
@@ -1161,7 +1164,10 @@ exit 0
             Assert.True(File.Exists(manifestPath), $"Manifest not found: {manifestPath}");
             Assert.True(Directory.Exists(publicDir), $"Public dir not found: {publicDir}");
 
+            // Exclude *.Tests.ps1 — Pester test files live next to the functions they
+            // exercise but do not define exported functions of their own.
             var publicBaseNames = Directory.EnumerateFiles(publicDir, "*.ps1")
+                .Where(p => !p.EndsWith(".Tests.ps1", StringComparison.OrdinalIgnoreCase))
                 .Select(Path.GetFileNameWithoutExtension)
                 .Where(n => !string.IsNullOrEmpty(n))
                 .ToHashSet(StringComparer.Ordinal);


### PR DESCRIPTION
## Summary

Three pre-existing xUnit tests started failing on PR #140 (release `dev → master`) against changes that landed from #138 and #139:

- **PowerShell51CompatibilityTests.AllVbrScripts_ShouldContainOnlyAsciiCharacters** — 3 of the new Pester test files contained em-dash (U+2014) characters. The compat suite enforces ASCII-only for VBR scripts. Em-dashes replaced with hyphens. No behavior change.
- **VhcModuleUnitTests.VhcVbrConfigManifest_FunctionsToExport_CoversAllPublicScripts** — the xUnit manifest contract test scans `Public/*.ps1` and demands every entry in `FunctionsToExport`, but didn't exclude `*.Tests.ps1`. Excluded them in the directory enumeration. (The Pester sibling test in `vHC-VbrConfig.Manifest.Tests.ps1` already excluded them.)
- **VhcModuleUnitTests.GetVhcBackupSessions_IncludesAgentSessions_CallsComputerBackupJobSession** — integration test stubbed `Get-VBRBackupSession` and `Get-VBRComputerBackupJobSession` but not `Get-VBRJob`, which became a new dependency in PR #138's per-job iteration refactor. Added the `Get-VBRJob` stub returning empty array, so the agent-session fallback path runs cleanly.

## Test plan
- [x] All 30 Pester tests still green locally on macOS (`Get-NasInfo.Tests.ps1` + `Get-VhcBackupSessions.Tests.ps1` + `vHC-VbrConfig.Manifest.Tests.ps1`)
- [ ] Windows CI: expect the 5 failing xUnit tests (3 ASCII + 1 manifest + 1 BackupSessions) to flip green
- [ ] After merge: PR #140 (release `dev → master`) checks should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)