### PR TITLE
fix(module): exclude *.Tests.ps1 from psm1 dot-source loop

### DIFF
--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/vHC-VbrConfig.psm1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/vHC-VbrConfig.psm1
@@ -1,7 +1,12 @@
 #Requires -Version 5.1
 
-$Public  = @(Get-ChildItem -Path "$PSScriptRoot\Public\*.ps1"  -ErrorAction SilentlyContinue)
-$Private = @(Get-ChildItem -Path "$PSScriptRoot\Private\*.ps1" -ErrorAction SilentlyContinue)
+# Exclude *.Tests.ps1 - Pester test files live alongside the functions they
+# exercise but must not be dot-sourced by the module: they carry their own
+# #requires -Version 7.0 and would fail Import-Module on PS 5.1 hosts.
+$Public  = @(Get-ChildItem -Path "$PSScriptRoot\Public\*.ps1"  -ErrorAction SilentlyContinue |
+             Where-Object { $_.Name -notlike '*.Tests.ps1' })
+$Private = @(Get-ChildItem -Path "$PSScriptRoot\Private\*.ps1" -ErrorAction SilentlyContinue |
+             Where-Object { $_.Name -notlike '*.Tests.ps1' })
 
 foreach ($import in ($Public + $Private)) {
     try {


### PR DESCRIPTION
## Summary

Second-order fix from PR #140 (release `dev → master`). After PR #141 fixed the ASCII / xUnit-test-side issues, the integration runs (`integration-test-vbr`, `integration-test-vbr-12`, `integration-test-vbr-13-sql`) surfaced a new failure mode: the module's `.psm1` dot-sources every `Public/*.ps1` and `Private/*.ps1`, which on the PR #138 tree means it tries to dot-source `Get-VhcBackupSessions.Tests.ps1`. That test file declares `#requires -Version 7.0`; the integration runners use Windows PowerShell 5.1, so `Import-Module` fails with:

```
Import-Module : Failed to import function from ...Get-VhcBackupSessions.Tests.ps1:
The script ... cannot be run because it contained a #requires statement for
Windows PowerShell Version 7.0.
```

Filter `*.Tests.ps1` out of both the `Public` and `Private` Get-ChildItem results in the `.psm1`. PR #141 already applied the same convention to the xUnit `VhcVbrConfigManifest_FunctionsToExport_CoversAllPublicScripts` test.

## Test plan
- [x] Pester suite still 28/28 green locally on macOS (`pwsh` + Pester 5.7) after the `.psm1` change
- [ ] Windows CI: expect `integration-test-vbr*` to load the module cleanly and `build-and-test` to remain green
- [ ] PR #140 (release `dev → master`) checks should clear after this merges to `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)