### PR TITLE
fix(html): harden ObjectStorageRepos renderer against missing dynamic properties

### DIFF
--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CObjectStorageReposTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CObjectStorageReposTable.cs
@@ -46,10 +46,18 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Repositories
                 {
                     foreach (var item in data)
                     {
+                        // Cast to IDictionary<string,object> + TryGetValue so a row missing a
+                        // column (CsvHelper FastDynamicObject quirk on header-only / partial
+                        // CSVs) does not throw RuntimeBinderException. Matches the safe
+                        // pattern in CUserRolesTable.
+                        var row = (IDictionary<string, object>)item;
+                        string Get(string key) =>
+                            row.TryGetValue(key, out var v) ? (string)(v ?? "") : "";
+
                         s += "<tr>";
 
-                        string name = (string)(item.Name ?? "");
-                        string account = (string)(item.Account ?? "");
+                        string name = Get("Name");
+                        string account = Get("Account");
                         if (scrub)
                         {
                             name = CGlobals.Scrubber.ScrubItem(name, ScrubItemType.Item);
@@ -57,14 +65,14 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Repositories
                         }
 
                         s += this.form.TableDataLeftAligned(name, string.Empty);
-                        s += this.form.TableData((string)(item.Type ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.Bucket ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.Folder ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.Region ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.Endpoint ?? ""), string.Empty);
+                        s += this.form.TableData(Get("Type"), string.Empty);
+                        s += this.form.TableData(Get("Bucket"), string.Empty);
+                        s += this.form.TableData(Get("Folder"), string.Empty);
+                        s += this.form.TableData(Get("Region"), string.Empty);
+                        s += this.form.TableData(Get("Endpoint"), string.Empty);
                         s += this.form.TableData(account, string.Empty);
-                        s += this.form.TableData((string)(item.ConnectionType ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.Gateway ?? ""), string.Empty);
+                        s += this.form.TableData(Get("ConnectionType"), string.Empty);
+                        s += this.form.TableData(Get("Gateway"), string.Empty);
 
                         s += "</tr>";
                     }


### PR DESCRIPTION
## Summary

Final fix to unblock PR #140 (release `dev → master`). After PR #142 cleared the integration-test loader-path failures, `integration-test-vbr` surfaced a downstream rendering bug:

> `Failed to render Object Storage Repositories table: FastDynamicObject does not contain a definition for 'Name'.`

`CObjectStorageReposTable.cs` accessed CSV dynamic rows via `item.Name`, `item.Bucket`, etc. When CsvHelper's `FastDynamicObject` lacks a property (header-only CSV, partial row, header-normalization quirk), the access throws `RuntimeBinderException` — the catch block swallowed the throw but the entire table failed to render, and the CI log scanner flagged the error.

The canonical safe pattern is already established in this codebase at `CUserRolesTable.cs:45-53` and `CHtmlTables.cs:673`: cast to `IDictionary<string,object>` and use `TryGetValue`. Aligning this table with that pattern.

## Why this surfaced now
The `ObjectStorageRepos` collector was previously unreachable (manifest export bug fixed in `59e2621` / PR #138). The renderer was never invoked end-to-end on any CI runner until today. The bug has been latent since the table was added.

## Scope
Single file: `vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CObjectStorageReposTable.cs`. Foreach body only (lines 47-70). +17/-9 lines. No PowerShell change — `Export-VhciCsv.ps1:34` already skips empty exports correctly.

## Test plan
- [x] All 30 Pester tests still green locally on macOS (`Get-NasInfo.Tests.ps1` + `Get-VhcBackupSessions.Tests.ps1` + `vHC-VbrConfig.Manifest.Tests.ps1`)
- [x] Static review: no remaining `item.PropertyName` dynamic accesses inside the foreach body (`grep -nE 'item\.\w+'` returns zero hits)
- [ ] Windows CI: `build-and-test` should remain green; `integration-test-vbr*` should flip to PASS
- [ ] PR #140 (release `dev → master`) should clear after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)