### PR TITLE
feat(cloud-connect): gateway RAM fix, tenant performance triage table

### DIFF
--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlBodyHelper.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlBodyHelper.cs
@@ -226,6 +226,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR
             this.HTMLSTRING += this.tables.AddCloudConnectHeader();
             this.CloudGatewaysTable();
             this.CloudGatewayPoolsTable();
+            this.CloudTenantPerformanceTable();
             this.CloudTenantsTable();
             this.CloudTenantBackupResourcesTable();
             this.CloudTenantReplicationResourcesTable();
@@ -245,6 +246,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR
         private void CloudGatewayPoolsTable()
         {
             this.HTMLSTRING += this.tables.AddCloudGatewayPoolsTable(this.SCRUB);
+        }
+
+        private void CloudTenantPerformanceTable()
+        {
+            this.HTMLSTRING += this.tables.AddCloudTenantPerformanceTable(this.SCRUB);
         }
 
         private void CloudTenantsTable()

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlCompiler.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlCompiler.cs
@@ -515,6 +515,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR
                 nav += this.form.NavSection("Cloud Connect",
                     this.form.NavLink("cloudgateways", "Gateways") +
                     this.form.NavLink("cloudgatewaypools", "Gateway Pools") +
+                    this.form.NavLink("cloudtenantperf", "Tenant Performance") +
                     this.form.NavLink("cloudtenants", "Tenants") +
                     this.form.NavLink("cloudtenantbackup", "Tenant Backup Storage") +
                     this.form.NavLink("cloudtenantreplica", "Tenant Replica Resources") +

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
@@ -1503,6 +1503,12 @@ namespace VeeamHealthCheck.Html.VBR
             return table.Render(scrub);
         }
 
+        public string AddCloudTenantPerformanceTable(bool scrub)
+        {
+            var table = new CCloudTenantPerformanceTable();
+            return table.Render(scrub);
+        }
+
         public string AddCloudTenantsTable(bool scrub)
         {
             var table = new CCloudTenantsTable();

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudConnectHelpers.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudConnectHelpers.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
+{
+    internal static class CCloudConnectHelpers
+    {
+        internal static string FormatMaxConcurrent(string raw) =>
+            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
+
+        internal static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
+            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
+             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
+                ? "—" : fieldValue;
+    }
+}

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTable.cs
@@ -80,7 +80,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
                         if (!string.IsNullOrEmpty(hostName) && serverLookup.TryGetValue(hostName, out var srvInfo))
                         {
                             cores = srvInfo.Cores;
-                            ram = srvInfo.Ram;
+                            ram = FormatRamGb(srvInfo.Ram);
                         }
                         s += this.form.TableData(cores, string.Empty);
                         s += this.form.TableData(ram, string.Empty);
@@ -98,6 +98,15 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             s += this.form.SectionEnd();
 
             return s;
+        }
+
+        private static string FormatRamGb(string rawBytes)
+        {
+            if (string.IsNullOrWhiteSpace(rawBytes)) return string.Empty;
+            if (!long.TryParse(rawBytes.Trim(), System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out long bytes)) return rawBytes;
+            long gb = (long)System.Math.Round(bytes / (1024d * 1024d * 1024d));
+            return $"{gb} GB";
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTable.cs
@@ -54,10 +54,10 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
 
                         s += this.form.TableDataLeftAligned(name, string.Empty);
                         s += this.form.TableData((string)(item.enabled ?? ""), string.Empty);
-                        s += this.form.TableData(FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
                         s += this.form.TableData(throttlingEnabled, string.Empty);
-                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
-                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
 
                         s += "</tr>";
                     }
@@ -73,12 +73,5 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             return s;
         }
 
-        private static string FormatMaxConcurrent(string raw) =>
-            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
-
-        private static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
-            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
-             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
-                ? "—" : fieldValue;
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTable.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using System.Linq;
+using VeeamHealthCheck.Functions.Reporting.CsvHandlers;
+using VeeamHealthCheck.Functions.Reporting.Html.Shared;
+using VeeamHealthCheck.Scrubber;
+using VeeamHealthCheck.Shared;
+
+namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
+{
+    internal class CCloudTenantPerformanceTable
+    {
+        private readonly CHtmlFormatting form = new();
+
+        public CCloudTenantPerformanceTable() { }
+
+        public string Render(bool scrub)
+        {
+            string s = this.form.SectionStartWithButton("cloudtenantperf", "Tenant Performance Settings", "Tenant Performance Settings");
+
+            s += this.form.TableHeaderLeftAligned("Tenant", string.Empty);
+            s += this.form.TableHeader("Enabled", string.Empty);
+            s += this.form.TableHeader("Max Concurrent Tasks", string.Empty);
+            s += this.form.TableHeader("Bandwidth Throttling", string.Empty);
+            s += this.form.TableHeader("Max Bandwidth", string.Empty);
+            s += this.form.TableHeader("Bandwidth Unit", string.Empty);
+
+            s += this.form.TableHeaderEnd();
+            s += this.form.TableBodyStart();
+
+            try
+            {
+                CCsvParser c = new();
+                var data = c.GetDynamicCloudTenants().ToList();
+
+                if (!data.Any())
+                {
+                    s += "<tr><td colspan='6' style='text-align: center; padding: 20px; color: #666;'><em>No cloud tenants detected.</em></td></tr>";
+                }
+                else
+                {
+                    foreach (var item in data)
+                    {
+                        s += "<tr>";
+
+                        string name = (string)(item.name ?? "");
+                        if (scrub)
+                        {
+                            name = CGlobals.Scrubber.ScrubItem(name, ScrubItemType.Item);
+                        }
+
+                        string throttlingEnabled = (string)(item.throttlingenabled ?? "");
+
+                        s += this.form.TableDataLeftAligned(name, string.Empty);
+                        s += this.form.TableData((string)(item.enabled ?? ""), string.Empty);
+                        s += this.form.TableData(FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
+                        s += this.form.TableData(throttlingEnabled, string.Empty);
+                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
+                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
+
+                        s += "</tr>";
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                CGlobals.Logger.Error("Failed to render Cloud Tenant Performance table: " + e.Message);
+            }
+
+            s += this.form.SectionEnd();
+
+            return s;
+        }
+
+        private static string FormatMaxConcurrent(string raw) =>
+            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
+
+        private static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
+            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
+             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
+                ? "—" : fieldValue;
+    }
+}

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTable.cs
@@ -37,8 +37,8 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             s += this.form.TableHeader("Rental Replicas", string.Empty);
             s += this.form.TableHeader("Max Concurrent Tasks", string.Empty);
             s += this.form.TableHeader("Throttling Enabled", string.Empty);
-            s += this.form.TableHeader("Throttle Value", string.Empty);
-            s += this.form.TableHeader("Throttle Unit", string.Empty);
+            s += this.form.TableHeader("Max Bandwidth", string.Empty);
+            s += this.form.TableHeader("Bandwidth Unit", string.Empty);
             s += this.form.TableHeader("Gateway Selection", string.Empty);
             s += this.form.TableHeader("Gateway Pool", string.Empty);
             s += this.form.TableHeader("Gateway Failover", string.Empty);
@@ -93,10 +93,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
                         s += this.form.TableData((string)(item.rentalserverbackupcount ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.rentalworkstationbackupcount ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.rentalreplicacount ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.maxconcurrenttask ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.throttlingenabled ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.throttlingvalue ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.throttlingunit ?? ""), string.Empty);
+                        s += this.form.TableData(FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
+                        string throttlingEnabled = (string)(item.throttlingenabled ?? "");
+                        s += this.form.TableData(throttlingEnabled, string.Empty);
+                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
+                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
                         s += this.form.TableData((string)(item.gatewayselectiontype ?? ""), string.Empty);
                         s += this.form.TableData(gatewayPoolName, string.Empty);
                         s += this.form.TableData((string)(item.gatewayfailoverenabled ?? ""), string.Empty);
@@ -118,5 +119,13 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
 
             return s;
         }
+
+        private static string FormatMaxConcurrent(string raw) =>
+            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
+
+        private static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
+            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
+             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
+                ? "—" : fieldValue;
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTable.cs
@@ -93,11 +93,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
                         s += this.form.TableData((string)(item.rentalserverbackupcount ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.rentalworkstationbackupcount ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.rentalreplicacount ?? ""), string.Empty);
-                        s += this.form.TableData(FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
                         string throttlingEnabled = (string)(item.throttlingenabled ?? "");
                         s += this.form.TableData(throttlingEnabled, string.Empty);
-                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
-                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
                         s += this.form.TableData((string)(item.gatewayselectiontype ?? ""), string.Empty);
                         s += this.form.TableData(gatewayPoolName, string.Empty);
                         s += this.form.TableData((string)(item.gatewayfailoverenabled ?? ""), string.Empty);
@@ -120,12 +120,5 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             return s;
         }
 
-        private static string FormatMaxConcurrent(string raw) =>
-            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
-
-        private static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
-            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
-             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
-                ? "—" : fieldValue;
     }
 }

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTableTests.cs
@@ -25,10 +25,6 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
         private const string GatewayHeaders =
             "name,description,ipaddress,networkmode,incomingport,natport,hostname,enabled";
 
-        // Server CSV: 15 required columns (0–14), indices match CServerCsvInfos.
-        // Index: 0=Info, 1=ParentId, 2=Id, 3=Uid, 4=Name, 5=Reference, 6=Description,
-        //        7=IsUnavailable, 8=Type, 9=ApiVersion, 10=PhysHostId, 11=ProxyServicesCreds,
-        //        12=Cores, 13=CPU, 14=Ram
         private const string ServerHeaders =
             "Info,ParentId,Id,Uid,Name,Reference,Description,IsUnavailable,Type,ApiVersion,PhysHostId,ProxyServicesCreds,Cores,CPU,Ram";
 

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTableTests.cs
@@ -22,11 +22,21 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
     {
         public CCloudGatewaysTableTests() : base("VhcCloudGatewaysTests_") { }
 
-        private const string Headers =
+        private const string GatewayHeaders =
             "name,description,ipaddress,networkmode,incomingport,natport,hostname,enabled";
 
+        // Server CSV: 15 required columns (0–14), indices match CServerCsvInfos.
+        // Index: 0=Info, 1=ParentId, 2=Id, 3=Uid, 4=Name, 5=Reference, 6=Description,
+        //        7=IsUnavailable, 8=Type, 9=ApiVersion, 10=PhysHostId, 11=ProxyServicesCreds,
+        //        12=Cores, 13=CPU, 14=Ram
+        private const string ServerHeaders =
+            "Info,ParentId,Id,Uid,Name,Reference,Description,IsUnavailable,Type,ApiVersion,PhysHostId,ProxyServicesCreds,Cores,CPU,Ram";
+
         private void WriteCsv(string rows) =>
-            File.WriteAllText(Path.Combine(VbrDir, "_CloudGateways.csv"), Headers + "\n" + rows);
+            File.WriteAllText(Path.Combine(VbrDir, "_CloudGateways.csv"), GatewayHeaders + "\n" + rows);
+
+        private void WriteServerCsv(string rows) =>
+            File.WriteAllText(Path.Combine(VbrDir, "_Servers.csv"), ServerHeaders + "\n" + rows);
 
         [Fact]
         public void Render_NoData_ShowsEmptyStateMessage()
@@ -59,6 +69,44 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             Assert.DoesNotContain("ACME-Gateway", html);
             Assert.DoesNotContain("acme.corp", html);
             // non-PII column still renders
+            Assert.Contains("DirectMode", html);
+        }
+
+        [Fact]
+        public void Render_ServerRamPresent_DisplaysGigabytes()
+        {
+            // 410665353216 bytes = 382.something GB → rounds to 382
+            WriteCsv("ACME-Gateway,Edge gateway,203.0.113.10,DirectMode,6180,33,gw-host01,True");
+            WriteServerCsv("info1,parentid1,id1,uid1,gw-host01,ref1,desc1,False,Windows,12,physid1,creds1,32,Intel Xeon,410665353216");
+
+            string html = new CCloudGatewaysTable().Render(scrub: false);
+
+            Assert.Contains("382 GB", html);
+            Assert.DoesNotContain("410665353216", html);
+        }
+
+        [Fact]
+        public void Render_ServerRamUnparseable_DisplaysRawValue()
+        {
+            WriteCsv("ACME-Gateway,Edge gateway,203.0.113.10,DirectMode,6180,33,gw-host01,True");
+            WriteServerCsv("info1,parentid1,id1,uid1,gw-host01,ref1,desc1,False,Windows,12,physid1,creds1,32,Intel Xeon,not-a-number");
+
+            string html = new CCloudGatewaysTable().Render(scrub: false);
+
+            Assert.Contains("not-a-number", html);
+        }
+
+        [Fact]
+        public void Render_ServerRamEmpty_RendersWithoutCrash()
+        {
+            WriteCsv("ACME-Gateway,Edge gateway,203.0.113.10,DirectMode,6180,33,gw-host01,True");
+            WriteServerCsv("info1,parentid1,id1,uid1,gw-host01,ref1,desc1,False,Windows,12,physid1,creds1,32,Intel Xeon,");
+
+            // Should not throw; no raw bytes string in output
+            string html = new CCloudGatewaysTable().Render(scrub: false);
+
+            Assert.DoesNotContain("No cloud gateways detected", html);
+            // Empty RAM — just verify the row rendered and no byte-style number leaked
             Assert.Contains("DirectMode", html);
         }
     }

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTableTests.cs
@@ -7,21 +7,11 @@ using Xunit;
 
 namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
 {
-    /// <summary>
-    /// Characterization tests for the Cloud Connect "Tenant Performance Settings" renderer.
-    /// Reuses VbrTableScrubTestBase so the renderer's CCsvParser reads our sample
-    /// _CloudTenants.csv instead of live VBR output.
-    ///
-    /// The table reads the same _CloudTenants.csv as CCloudTenantsTable; it renders
-    /// only the performance-relevant columns (6 columns total).
-    /// Scrubbed PII field: name only.
-    /// </summary>
     [Collection("GlobalState")]
     public class CCloudTenantPerformanceTableTests : VbrTableScrubTestBase
     {
         public CCloudTenantPerformanceTableTests() : base("VhcCloudTenantPerfTests_") { }
 
-        // Same 29-column header as CCloudTenantsTable — the renderer reads the same CSV file.
         private const string Headers =
             "name,description,enabled,type,lastactive,lastresult,vmcount,servercount,workstationcount,replicacount," +
             "newvmbackupcount,newserverbackupcount,newworkstationbackupcount,newreplicacount," +

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTableTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System.IO;
+using VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect;
+using VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
+{
+    /// <summary>
+    /// Characterization tests for the Cloud Connect "Tenant Performance Settings" renderer.
+    /// Reuses VbrTableScrubTestBase so the renderer's CCsvParser reads our sample
+    /// _CloudTenants.csv instead of live VBR output.
+    ///
+    /// The table reads the same _CloudTenants.csv as CCloudTenantsTable; it renders
+    /// only the performance-relevant columns (6 columns total).
+    /// Scrubbed PII field: name only.
+    /// </summary>
+    [Collection("GlobalState")]
+    public class CCloudTenantPerformanceTableTests : VbrTableScrubTestBase
+    {
+        public CCloudTenantPerformanceTableTests() : base("VhcCloudTenantPerfTests_") { }
+
+        // Same 29-column header as CCloudTenantsTable — the renderer reads the same CSV file.
+        private const string Headers =
+            "name,description,enabled,type,lastactive,lastresult,vmcount,servercount,workstationcount,replicacount," +
+            "newvmbackupcount,newserverbackupcount,newworkstationbackupcount,newreplicacount," +
+            "rentalvmbackupcount,rentalserverbackupcount,rentalworkstationbackupcount,rentalreplicacount," +
+            "maxconcurrenttask,throttlingenabled,throttlingvalue,throttlingunit,gatewayselectiontype," +
+            "gatewaypoolname,gatewayfailoverenabled,leaseexpirationenabled,leaseexpirationdate," +
+            "backupprotectionenabled,backupprotectionperiod";
+
+        private void WriteCsv(string rows) =>
+            File.WriteAllText(Path.Combine(VbrDir, "_CloudTenants.csv"), Headers + "\n" + rows);
+
+        [Fact]
+        public void Render_NoData_ShowsEmptyStateMessage()
+        {
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+            Assert.Contains("No cloud tenants detected", html);
+        }
+
+        [Fact]
+        public void Render_ColumnHeaders_ContainsAllSixHeaders()
+        {
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("Tenant", html);
+            Assert.Contains("Enabled", html);
+            Assert.Contains("Max Concurrent Tasks", html);
+            Assert.Contains("Bandwidth Throttling", html);
+            Assert.Contains("Max Bandwidth", html);
+            Assert.Contains("Bandwidth Unit", html);
+        }
+
+        [Fact]
+        public void Render_SectionId_ContainsCloudTenantPerfAnchor()
+        {
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("cloudtenantperf", html);
+        }
+
+        [Fact]
+        public void Render_MaxConcurrentTaskZero_DisplaysUnlimited()
+        {
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,0,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("Unlimited", html);
+        }
+
+        [Fact]
+        public void Render_MaxConcurrentTaskPositive_DisplaysNumericValue()
+        {
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,8,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("8", html);
+            Assert.DoesNotContain("Unlimited", html);
+        }
+
+        [Fact]
+        public void Render_ThrottlingDisabled_DisplaysDashForValueAndUnit()
+        {
+            // ThrottlingEnabled=False → value and unit render as "—"
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,4,False,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("—", html);
+            Assert.DoesNotContain("500", html);
+            Assert.DoesNotContain("MbytePerSec", html);
+        }
+
+        [Fact]
+        public void Render_ThrottlingEnabled_DisplaysValueAndUnit()
+        {
+            // ThrottlingEnabled=True → value and unit render as actual values
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,4,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("500", html);
+            Assert.Contains("MbytePerSec", html);
+        }
+
+        [Fact]
+        public void Render_ScrubTrue_AnonymizesTenantNameOnly()
+        {
+            // Name is scrubbed; numeric MCT value (8) must still appear
+            WriteCsv("SECRET-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,8,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: true);
+
+            Assert.DoesNotContain("SECRET-Tenant", html);
+            // MCT is a numeric field, not scrubbed
+            Assert.Contains("8", html);
+        }
+    }
+}

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTableTests.cs
@@ -43,8 +43,6 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
         [Fact]
         public void Render_ScrubFalse_RendersRawValues()
         {
-            // ThrottlingEnabled=False → value/unit render as "—" (new behavior).
-            // This test verifies the tenant name, description and non-throttle fields only.
             WriteCsv("ACME-Tenant,Production tenant for acme.corp,True,Standalone,2026-01-01,Success,12,3,4,2," +
                      "1,0,0,0,5,1,0,0,4,False,0,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
                      "2030-01-01,True,30");

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTableTests.cs
@@ -43,6 +43,8 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
         [Fact]
         public void Render_ScrubFalse_RendersRawValues()
         {
+            // ThrottlingEnabled=False → value/unit render as "—" (new behavior).
+            // This test verifies the tenant name, description and non-throttle fields only.
             WriteCsv("ACME-Tenant,Production tenant for acme.corp,True,Standalone,2026-01-01,Success,12,3,4,2," +
                      "1,0,0,0,5,1,0,0,4,False,0,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
                      "2030-01-01,True,30");
@@ -69,6 +71,70 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             Assert.DoesNotContain("acme.corp", html);
             // non-PII column still renders
             Assert.Contains("Standalone", html);
+        }
+
+        [Fact]
+        public void Render_MaxConcurrentTaskZero_DisplaysUnlimited()
+        {
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,0,False,0,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("Unlimited", html);
+        }
+
+        [Fact]
+        public void Render_MaxConcurrentTaskEmpty_DisplaysUnlimited()
+        {
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,,False,0,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("Unlimited", html);
+        }
+
+        [Fact]
+        public void Render_ThrottlingDisabled_DisplaysDashForValueAndUnit()
+        {
+            // ThrottlingEnabled=False → value and unit should show "—", not the raw values
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,4,False,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("—", html);
+            Assert.DoesNotContain("500", html);
+            Assert.DoesNotContain("MbytePerSec", html);
+        }
+
+        [Fact]
+        public void Render_ThrottlingEnabled_DisplaysActualValues()
+        {
+            // ThrottlingEnabled=True → value and unit should show actual values
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,4,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("500", html);
+            Assert.Contains("MbytePerSec", html);
+        }
+
+        [Fact]
+        public void Render_Headers_ContainsMaxBandwidthAndBandwidthUnit()
+        {
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("Max Bandwidth", html);
+            Assert.Contains("Bandwidth Unit", html);
+            Assert.DoesNotContain("Throttle Value", html);
+            Assert.DoesNotContain("Throttle Unit", html);
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses user feedback on the Cloud Connect report:

> "Works great. Couple of suggestions - it is missing the max concurrent task setting and bandwidth — this is where SPs get tripped up a lot with performance related issues. But I think you have enumerate through each tenant to get that. The other minor thing is the RAM for the gateway is shown in bytes not GB if that matters."

## Changes

### Gateway RAM display fix
- `CCloudGatewaysTable` was showing raw bytes (e.g. `410665353216`) for the RAM column despite the header reading "RAM (GB)"
- Added `FormatRamGb` helper: parses bytes string, divides by 1024³, returns `"N GB"` — fail-soft on unparseable input

### Tenant performance settings — display polish
- `MaxConcurrentTask = 0` (Veeam's "no limit" default) now renders as **"Unlimited"** instead of `0`
- Throttle value/unit cells render **"—"** when throttling is disabled — previously showed meaningless raw values
- Header renames: "Throttle Value" → **"Max Bandwidth"**, "Throttle Unit" → **"Bandwidth Unit"**

### New "Tenant Performance Settings" triage sub-table
- Focused 6-column view (Tenant, Enabled, Max Concurrent Tasks, Bandwidth Throttling, Max Bandwidth, Bandwidth Unit) rendered **before** the full 29-column Tenants table
- Reads the same `_CloudTenants.csv` — no new collection scripts
- Sidebar nav entry added at correct position

### Shared formatting helpers
- `CCloudConnectHelpers.cs` consolidates `FormatMaxConcurrent` and `FormatThrottleField` — used by both tenant tables

## Tests
- 3 new gateway RAM tests (`Render_ServerRamPresent_DisplaysGigabytes`, `Render_ServerRamUnparseable_DisplaysRawValue`, `Render_ServerRamEmpty_RendersWithoutCrash`)
- 5 new tenant display tests (MCT=0→Unlimited, throttling disabled/enabled, header names)
- 8 new `CCloudTenantPerformanceTableTests` covering all table behaviors

## Notes
- No changes to PowerShell collection scripts or CSV schemas — `MaxConcurrentTask`, `ThrottlingEnabled`, `ThrottlingValue`, `ThrottlingUnit` are confirmed direct properties on all VBRCloudTenant SDK types per official docs
- The "missing" concurrent task data was a display issue (0 rendering as blank), not a collection gap