### PR TITLE
Promote dev → master: report fixes (#125, #158, #146, #145, #49), Cloud Connect improvements, CI/release tooling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,11 +8,30 @@
 
 By contributing, you agree that your contributions will be licensed under the projects original open source license.
 
-## Description
+## Summary
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Brief description of the change and which issue is fixed.
 
 Fixes # (issue)
+
+---
+
+## Changelog
+
+> The sections below populate the GitHub release notes. Fill in what applies; remove sections that don't.
+
+### ✨ Features
+<!-- New features or enhancements — one bullet per line -->
+
+### 🐛 Bug Fixes
+<!-- Bug fixes — one bullet per line. Use "Fixes #N" to auto-close issues -->
+
+### 🧪 Tests & CI
+<!-- Test additions, CI/workflow improvements — one bullet per line -->
+
+---
+
+## Review Details
 
 ### Type of change
 

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -2260,77 +2260,119 @@ jobs:
     - name: Generate Release Notes
       id: release_notes
       run: |
-        # Fetch the last release tag to compare changes
+        $version   = "${{ needs.build-and-test.outputs.version }}"
+        $zipHash   = "${{ steps.release_hash.outputs.hash }}"
+        $sizeMB    = "${{ steps.release_hash.outputs.size_mb }}"
+        $commitSha = "${{ github.sha }}"
+        $repo      = "${{ github.repository }}"
+        $buildDate = "${{ github.event.head_commit.timestamp }}"
+
+        # Find last release tag
         $lastTag = git describe --tags --abbrev=0 2>$null
-        if (-not $lastTag) {
-          $lastTag = (git rev-list --max-parents=0 HEAD)
+        if (-not $lastTag) { $lastTag = git rev-list --max-parents=0 HEAD }
+
+        # Categorize commits by conventional commit prefix
+        $features = [System.Collections.Generic.List[string]]::new()
+        $fixes    = [System.Collections.Generic.List[string]]::new()
+        $testsCI  = [System.Collections.Generic.List[string]]::new()
+        $other    = [System.Collections.Generic.List[string]]::new()
+
+        foreach ($line in (git log "$lastTag..HEAD" --pretty=format:"%s|||%h" --no-merges)) {
+          if ([string]::IsNullOrWhiteSpace($line)) { continue }
+          $parts = $line -split '\|\|\|', 2
+          $subj  = $parts[0].Trim()
+          $sha   = if ($parts.Count -gt 1) { $parts[1].Trim() } else { '' }
+
+          if ($subj -match '^feat(?:\([^)]+\))?!?:\s*(.+)') {
+            $features.Add("- $($Matches[1].Trim()) ($sha)")
+          } elseif ($subj -match '^fix(?:\([^)]+\))?!?:\s*(.+)') {
+            $fixes.Add("- $($Matches[1].Trim()) ($sha)")
+          } elseif ($subj -match '^(?:test|ci|chore|docs|build|refactor|style|perf)(?:\([^)]+\))?!?:\s*(.+)') {
+            $testsCI.Add("- $($Matches[1].Trim()) ($sha)")
+          } else {
+            $other.Add("- $subj ($sha)")
+          }
         }
 
-        # Get commit messages since last release
-        $commits = git log "$lastTag..HEAD" --pretty=format:"- %s (%h)" --no-merges
-
-        # Find merged PRs by searching commit messages
-        $prNumbers = git log "$lastTag..HEAD" --pretty=format:"%s" |
-          Select-String -Pattern "#(\d+)" -AllMatches |
-          ForEach-Object { $_.Matches } |
-          ForEach-Object { $_.Groups[1].Value } |
+        # Extract issue numbers closed by commits in this range
+        $fixedIssues = (git log "$lastTag..HEAD" --pretty=format:"%B") |
+          Select-String -Pattern '(?:Fixes|Closes|Resolves)\s+#(\d+)' -AllMatches |
+          ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value } |
           Sort-Object -Unique
 
-        # Extract issues fixed (Fixes #XX, Closes #XX, Resolves #XX)
-        $fixedIssues = git log "$lastTag..HEAD" --pretty=format:"%B" |
-          Select-String -Pattern "(?:Fixes|Closes|Resolves)\s+#(\d+)" -AllMatches |
-          ForEach-Object { $_.Matches } |
-          ForEach-Object { $_.Groups[1].Value } |
-          Sort-Object -Unique
+        # Build release notes as a list of lines, then join — no heredoc indentation issues
+        $n = [System.Collections.Generic.List[string]]::new()
+        $n.Add("## Veeam Health Check v$version")
+        $n.Add("")
 
-        # Get list of changed files
-        $changedFiles = git diff --name-only "$lastTag..HEAD" | Measure-Object | Select-Object -ExpandProperty Count
-
-        # Build changelog section
-        $changelog = ""
-        if ($commits) {
-          $changelog = @"
-        ### 📝 Changes in This Release
-
-        $($commits -join "`n        ")
-
-        **Files Changed:** $changedFiles
-        "@
+        if ($features.Count -gt 0) {
+          $n.Add("### ✨ Features")
+          $n.Add("")
+          $features | ForEach-Object { $n.Add($_) }
+          $n.Add("")
         }
 
-        # Build issues section
-        $issuesSection = ""
-        if ($fixedIssues) {
-          $issuesList = $fixedIssues | ForEach-Object { "- Fixes #$_ - https://github.com/${{ github.repository }}/issues/$_" }
-          $issuesSection = @"
-
-        ### 🐛 Issues Resolved
-
-        $($issuesList -join "`n")
-        "@
+        if ($fixes.Count -gt 0 -or $fixedIssues.Count -gt 0) {
+          $n.Add("### 🐛 Bug Fixes")
+          $n.Add("")
+          $fixes | ForEach-Object { $n.Add($_) }
+          $fixedIssues | ForEach-Object { $n.Add("- Fixes #$_ ([#$_](https://github.com/$repo/issues/$_))") }
+          $n.Add("")
         }
 
-        # Build PR section
-        $prSection = ""
-        if ($prNumbers) {
-          $prList = $prNumbers | ForEach-Object { "- PR #$_ - https://github.com/${{ github.repository }}/pull/$_" }
-          $prSection = @"
-
-        ### 🔀 Pull Requests
-
-        $($prList -join "`n")
-        "@
+        if ($testsCI.Count -gt 0) {
+          $n.Add("### 🧪 Tests & CI")
+          $n.Add("")
+          $testsCI | ForEach-Object { $n.Add($_) }
+          $n.Add("")
         }
 
-        # Combine all sections
-        $releaseNotes = @"
-        $changelog$issuesSection$prSection
-        "@
+        if ($other.Count -gt 0) {
+          $n.Add("### 📝 Other Changes")
+          $n.Add("")
+          $other | ForEach-Object { $n.Add($_) }
+          $n.Add("")
+        }
 
-        # Output multiline content using heredoc syntax (no URL encoding needed)
-        echo "changelog<<EOF" >> $env:GITHUB_OUTPUT
-        echo $releaseNotes >> $env:GITHUB_OUTPUT
-        echo "EOF" >> $env:GITHUB_OUTPUT
+        $hasChanges = ($features.Count + $fixes.Count + $fixedIssues.Count + $testsCI.Count + $other.Count) -gt 0
+        if ($hasChanges) { $n.Add("---"); $n.Add("") }
+
+        $n.Add("### ✅ Security & Quality Verification")
+        $n.Add("- ✅ Build & Unit Tests: **Passed**")
+        $n.Add("- ✅ VirusTotal Scan: **Clean** (0 detections)")
+        $n.Add("- ✅ Integration Tests: **Passed** (VBR v12, v13, v13+SQL)")
+        $n.Add("- ✅ Code Quality: Analyzed")
+        $n.Add("")
+        $n.Add("### 📦 Download")
+        $n.Add("**VeeamHealthCheck-$version.zip** ($sizeMB MB)")
+        $n.Add("")
+        $n.Add("**SHA256 Checksum:**")
+        $n.Add('```')
+        $n.Add($zipHash)
+        $n.Add('```')
+        $n.Add("")
+        $n.Add("**Verification Command:**")
+        $n.Add('```powershell')
+        $n.Add("(Get-FileHash `"VeeamHealthCheck-$version.zip`").Hash")
+        $n.Add('```')
+        $n.Add("")
+        $n.Add("### 📋 Requirements")
+        $n.Add("- Windows 7 or later")
+        $n.Add("- .NET 8 runtime (included in self-contained build)")
+        $n.Add("- PowerShell 5.1 or later")
+        $n.Add("")
+        $n.Add("### 🚀 Quick Start")
+        $n.Add("1. Download the ZIP file above")
+        $n.Add("2. Extract to a folder")
+        $n.Add("3. Run ``VeeamHealthCheck.exe``")
+        $n.Add("")
+        $n.Add("---")
+        $n.Add("")
+        $n.Add("**Built from:** [$commitSha](https://github.com/$repo/commit/$commitSha)")
+        $n.Add("**Build Date:** $buildDate")
+
+        ($n -join "`n") | Out-File -FilePath "release_notes.md" -Encoding UTF8
+        Write-Host "Generated release notes"
 
     - name: Create GitHub Release
       id: create_release
@@ -2338,44 +2380,7 @@ jobs:
       with:
         tag_name: v${{ needs.build-and-test.outputs.version }}
         name: Veeam Health Check v${{ needs.build-and-test.outputs.version }}
-        body: |
-          ## Veeam Health Check v${{ needs.build-and-test.outputs.version }}
-
-          ${{ steps.release_notes.outputs.changelog }}
-
-          ### ✅ Security & Quality Verification
-          - ✅ Build & Unit Tests: **Passed**
-          - ✅ VirusTotal Scan: **Clean** (0 detections)
-          - ✅ Integration Tests: **Passed** (VBR v12, v13, v13+SQL)
-          - ✅ Code Quality: Analyzed
-
-          ### 📦 Download
-          **VeeamHealthCheck-${{ needs.build-and-test.outputs.version }}.zip** (${{ steps.release_hash.outputs.size_mb }} MB)
-
-          **SHA256 Checksum:**
-          ```
-          ${{ steps.release_hash.outputs.hash }}
-          ```
-
-          **Verification Command:**
-          ```powershell
-          (Get-FileHash "VeeamHealthCheck-${{ needs.build-and-test.outputs.version }}.zip").Hash
-          ```
-
-          ### 📋 Requirements
-          - Windows 7 or later
-          - .NET 8 runtime (included in self-contained build)
-          - PowerShell 5.1 or later
-
-          ### 🚀 Quick Start
-          1. Download the ZIP file above
-          2. Extract to a folder
-          3. Run `VeeamHealthCheck.exe`
-
-          ---
-
-          **Built from:** [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
-          **Build Date:** ${{ github.event.head_commit.timestamp }}
+        body_path: release_notes.md
         draft: false
         prerelease: false
         files: release-files/*

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -139,7 +139,7 @@ jobs:
 
     - name: VirusTotal Scan
       id: virustotal
-      if: ${{ !inputs.skip_virustotal && secrets.VT_API_KEY != '' }}
+      if: ${{ !inputs.skip_virustotal }}
       shell: pwsh
       run: |
         $version = "${{ steps.get_version.outputs.version }}"
@@ -194,7 +194,7 @@ jobs:
 
     - name: Set VirusTotal defaults
       id: vt_defaults
-      if: ${{ inputs.skip_virustotal || secrets.VT_API_KEY == '' }}
+      if: ${{ inputs.skip_virustotal }}
       shell: pwsh
       env:
         SKIP_VIRUSTOTAL: ${{ inputs.skip_virustotal }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -157,7 +157,13 @@ jobs:
             $uploadUri = $urlResp.data
             Write-Host "Got large-file upload URL"
           }
-          $uploadResponse = Invoke-RestMethod -Uri $uploadUri -Method Post -Headers $headers -Form @{ file = Get-Item $zipPath }
+          # Use curl.exe for multipart upload — Invoke-RestMethod -Form mishandles VT's pre-signed URLs
+          Write-Host "Uploading $fileSizeMB MB to VirusTotal..."
+          $curlArgs = @('--silent', '--show-error', '--request', 'POST',
+                        '--header', "x-apikey: $apiKey",
+                        '--form', "file=@`"$zipPath`"",
+                        $uploadUri)
+          $uploadResponse = (& curl.exe @curlArgs) | ConvertFrom-Json
           $analysisId = $uploadResponse.data.id
           Write-Host "Uploaded to VirusTotal ($fileSizeMB MB). Analysis ID: $analysisId"
 

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -237,62 +237,114 @@ jobs:
         $buildDate = (Get-Date).ToString("yyyy-MM-ddTHH:mm:ssZ")
 
         $vtEmoji = switch ($vtClean) {
-          "true" { "✅" }
-          "false" { "⚠️" }
+          "true"    { "✅" }
+          "false"   { "⚠️" }
           "skipped" { "⏭️" }
-          default { "❓" }
+          default   { "❓" }
+        }
+
+        # Parse structured changelog sections from PR body
+        # Sections: ### ✨ Features | ### 🐛 Bug Fixes | ### 🧪 Tests & CI
+        $features = [System.Collections.Generic.List[string]]::new()
+        $fixes    = [System.Collections.Generic.List[string]]::new()
+        $testsCI  = [System.Collections.Generic.List[string]]::new()
+
+        if (Test-Path "pr_body.txt") {
+          $currentSection = $null
+          foreach ($line in (Get-Content "pr_body.txt")) {
+            if     ($line -match '^###\s+.*\bFeatures?\b')              { $currentSection = 'features' }
+            elseif ($line -match '^###\s+.*\bBug\s+Fixes?\b')          { $currentSection = 'fixes' }
+            elseif ($line -match '^###\s+.*\b(?:Tests?\b|CI\b)')       { $currentSection = 'testsci' }
+            elseif ($line -match '^##')                                 { $currentSection = $null }
+            elseif ($currentSection) {
+              $t = $line.Trim()
+              if ($t -match '^-\s+\S' -and $t -notmatch '^<!--') {
+                switch ($currentSection) {
+                  'features' { $features.Add($t) }
+                  'fixes'    { $fixes.Add($t) }
+                  'testsci'  { $testsCI.Add($t) }
+                }
+              }
+            }
+          }
         }
 
         # Build release notes
-        $notes = @()
-        $notes += "## Veeam Health Check v$version"
-        $notes += ""
+        $notes = [System.Collections.Generic.List[string]]::new()
+        $notes.Add("## Veeam Health Check v$version")
+        $notes.Add("")
 
-        # Add changelog if available
-        if (Test-Path "pr_body.txt") {
-          $prBody = Get-Content "pr_body.txt" -Raw
-          $notes += "### 🆕 What's New"
-          $notes += ""
-          $notes += $prBody
-          $notes += ""
-          $notes += "---"
-          $notes += ""
+        # Structured changelog sections (populated from PR body)
+        $hasChangelog = ($features.Count + $fixes.Count + $testsCI.Count) -gt 0
+
+        if ($features.Count -gt 0) {
+          $notes.Add("### ✨ Features")
+          $notes.Add("")
+          $features | ForEach-Object { $notes.Add($_) }
+          $notes.Add("")
         }
 
-        $notes += "### ✅ Security & Quality Verification"
-        $notes += "- ✅ Build & Unit Tests: **Passed**"
-        $notes += "- $vtEmoji VirusTotal Scan: **$vtResult**"
-        $notes += "- ✅ Code Quality: Analyzed"
-        $notes += ""
-        $notes += "### 📦 Download"
-        $notes += "**VeeamHealthCheck-$version.zip** ($sizeMB MB)"
-        $notes += ""
-        $notes += "**SHA256 Checksum:**"
-        $notes += '```'
-        $notes += $hash
-        $notes += '```'
-        $notes += ""
-        $notes += "**Verification Command:**"
-        $notes += '```powershell'
-        $notes += "(Get-FileHash `"VeeamHealthCheck-$version.zip`").Hash"
-        $notes += '```'
-        $notes += ""
-        $notes += "### 📋 Requirements"
-        $notes += "- Windows 7 or later"
-        $notes += "- .NET 8 runtime (included in self-contained build)"
-        $notes += "- PowerShell 5.1 or later"
-        $notes += ""
-        $notes += "### 🚀 Quick Start"
-        $notes += "1. Download the ZIP file above"
-        $notes += "2. Extract to a folder"
-        $notes += "3. Run ``VeeamHealthCheck.exe``"
-        $notes += ""
-        $notes += "---"
-        $notes += ""
-        $notes += "**Built from:** [$commitSha](https://github.com/$repo/commit/$commitSha)"
-        $notes += "**Build Date:** $buildDate"
+        if ($fixes.Count -gt 0) {
+          $notes.Add("### 🐛 Bug Fixes")
+          $notes.Add("")
+          $fixes | ForEach-Object { $notes.Add($_) }
+          $notes.Add("")
+        }
 
-        $notes -join "`n" | Out-File -FilePath "release_notes.md" -Encoding UTF8
+        if ($testsCI.Count -gt 0) {
+          $notes.Add("### 🧪 Tests & CI")
+          $notes.Add("")
+          $testsCI | ForEach-Object { $notes.Add($_) }
+          $notes.Add("")
+        }
+
+        if ($hasChangelog) {
+          $notes.Add("---")
+          $notes.Add("")
+        } elseif (Test-Path "pr_body.txt") {
+          # Fallback for legacy/unstructured PR bodies
+          $notes.Add("### 🆕 What's New")
+          $notes.Add("")
+          Get-Content "pr_body.txt" | ForEach-Object { $notes.Add($_) }
+          $notes.Add("")
+          $notes.Add("---")
+          $notes.Add("")
+        }
+
+        $notes.Add("### ✅ Security & Quality Verification")
+        $notes.Add("- ✅ Build & Unit Tests: **Passed**")
+        $notes.Add("- $vtEmoji VirusTotal Scan: **$vtResult**")
+        $notes.Add("- ✅ Code Quality: Analyzed")
+        $notes.Add("")
+        $notes.Add("### 📦 Download")
+        $notes.Add("**VeeamHealthCheck-$version.zip** ($sizeMB MB)")
+        $notes.Add("")
+        $notes.Add("**SHA256 Checksum:**")
+        $notes.Add('```')
+        $notes.Add($hash)
+        $notes.Add('```')
+        $notes.Add("")
+        $notes.Add("**Verification Command:**")
+        $notes.Add('```powershell')
+        $notes.Add("(Get-FileHash `"VeeamHealthCheck-$version.zip`").Hash")
+        $notes.Add('```')
+        $notes.Add("")
+        $notes.Add("### 📋 Requirements")
+        $notes.Add("- Windows 7 or later")
+        $notes.Add("- .NET 8 runtime (included in self-contained build)")
+        $notes.Add("- PowerShell 5.1 or later")
+        $notes.Add("")
+        $notes.Add("### 🚀 Quick Start")
+        $notes.Add("1. Download the ZIP file above")
+        $notes.Add("2. Extract to a folder")
+        $notes.Add("3. Run ``VeeamHealthCheck.exe``")
+        $notes.Add("")
+        $notes.Add("---")
+        $notes.Add("")
+        $notes.Add("**Built from:** [$commitSha](https://github.com/$repo/commit/$commitSha)")
+        $notes.Add("**Build Date:** $buildDate")
+
+        ($notes -join "`n") | Out-File -FilePath "release_notes.md" -Encoding UTF8
         Write-Host "Generated release notes"
 
     - name: Upload artifact

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -364,8 +364,11 @@ jobs:
       shell: pwsh
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_VERSION: ${{ steps.get_version.outputs.version }}
+        IS_PRERELEASE: ${{ inputs.prerelease }}
+        GH_REPO: ${{ github.repository }}
       run: |
-        $version = "${{ steps.get_version.outputs.version }}"
+        $version = $env:RELEASE_VERSION
         $zipPath = "publish/VeeamHealthCheck-$version.zip"
         $notesFile = "release_notes.md"
 
@@ -376,10 +379,10 @@ jobs:
           gh release upload "v$version" $zipPath --clobber
         } else {
           Write-Host "Creating new release v$version..."
-          $prereleaseFlag = if ("${{ inputs.prerelease }}" -eq "true") { "--prerelease" } else { "" }
+          $prereleaseFlag = if ($env:IS_PRERELEASE -eq "true") { "--prerelease" } else { "" }
           gh release create "v$version" --title "Veeam Health Check v$version" --notes-file $notesFile $zipPath $prereleaseFlag
         }
-        Write-Host "Release URL: https://github.com/${{ github.repository }}/releases/tag/v$version"
+        Write-Host "Release URL: https://github.com/$env:GH_REPO/releases/tag/v$version"
 
     - name: Dry run summary
       if: ${{ inputs.dry_run }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -187,6 +187,7 @@ jobs:
             "vt_clean=unknown" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
         } catch {
+          Write-Host "VirusTotal error: $_"
           "vt_result=Scan failed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "vt_clean=error" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         }
@@ -321,9 +322,15 @@ jobs:
             $logLines = git log "$prevTag..HEAD" --no-merges --format="%s" 2>$null
             $featLines = [System.Collections.Generic.List[string]]::new()
             $fixLines  = [System.Collections.Generic.List[string]]::new()
+            $ciScopes = @('ci', 'release', 'release-notes', 'test', 'tests', 'deps', 'build')
             foreach ($msg in $logLines) {
-              if ($msg -match '^feat(\([^)]+\))?[!]?:\s*(.+)') { $featLines.Add("- $($Matches[2])") }
-              elseif ($msg -match '^fix(\([^)]+\))?[!]?:\s*(.+)')  { $fixLines.Add("- $($Matches[2])") }
+              if ($msg -match '^(feat|fix)(\(([^)]+)\))?[!]?:\s*(.+)') {
+                $scope = $Matches[3]
+                $text  = $Matches[4]
+                if ($scope -and ($ciScopes -contains $scope)) { continue }
+                if ($Matches[1] -eq 'feat') { $featLines.Add("- $text") }
+                else                        { $fixLines.Add("- $text") }
+              }
             }
             if ($featLines.Count -gt 0) {
               $notes.Add("### ✨ Features")

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -144,7 +144,7 @@ jobs:
       run: |
         $version = "${{ steps.get_version.outputs.version }}"
         $zipPath = "publish/VeeamHealthCheck-$version.zip"
-        $apiKey = "${{ secrets.VT_API_KEY }}"
+        $apiKey = "${{ secrets.VIRUSTOTAL_API_KEY }}"
         $headers = @{ "x-apikey" = $apiKey }
         $form = @{ file = Get-Item $zipPath }
 
@@ -314,6 +314,31 @@ jobs:
           $notes.Add("")
           $notes.Add("---")
           $notes.Add("")
+        } else {
+          # No PR body — auto-generate from git log since last tag
+          $prevTag = git describe --tags --abbrev=0 HEAD 2>$null
+          if ($LASTEXITCODE -eq 0 -and $prevTag) {
+            $logLines = git log "$prevTag..HEAD" --no-merges --format="%s" 2>$null
+            $featLines = [System.Collections.Generic.List[string]]::new()
+            $fixLines  = [System.Collections.Generic.List[string]]::new()
+            foreach ($msg in $logLines) {
+              if ($msg -match '^feat(\([^)]+\))?[!]?:\s*(.+)') { $featLines.Add("- $($Matches[2])") }
+              elseif ($msg -match '^fix(\([^)]+\))?[!]?:\s*(.+)')  { $fixLines.Add("- $($Matches[2])") }
+            }
+            if ($featLines.Count -gt 0) {
+              $notes.Add("### ✨ Features")
+              $notes.Add("")
+              $featLines | ForEach-Object { $notes.Add($_) }
+              $notes.Add("")
+            }
+            if ($fixLines.Count -gt 0) {
+              $notes.Add("### 🐛 Bug Fixes")
+              $notes.Add("")
+              $fixLines | ForEach-Object { $notes.Add($_) }
+              $notes.Add("")
+            }
+            if ($featLines.Count + $fixLines.Count -gt 0) { $notes.Add("---"); $notes.Add("") }
+          }
         }
 
         $notes.Add("### ✅ Security & Quality Verification")

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -11,6 +11,11 @@ on:
         description: 'Version override (leave empty to use AssemblyVersion from csproj)'
         required: false
         type: string
+      prerelease:
+        description: 'Mark as pre-release (beta/RC from dev branch)'
+        required: false
+        type: boolean
+        default: false
       skip_virustotal:
         description: 'Skip VirusTotal scan'
         required: false
@@ -371,7 +376,8 @@ jobs:
           gh release upload "v$version" $zipPath --clobber
         } else {
           Write-Host "Creating new release v$version..."
-          gh release create "v$version" --title "Veeam Health Check v$version" --notes-file $notesFile $zipPath
+          $prereleaseFlag = if ("${{ inputs.prerelease }}" -eq "true") { "--prerelease" } else { "" }
+          gh release create "v$version" --title "Veeam Health Check v$version" --notes-file $notesFile $zipPath $prereleaseFlag
         }
         Write-Host "Release URL: https://github.com/${{ github.repository }}/releases/tag/v$version"
 

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -146,12 +146,20 @@ jobs:
         $zipPath = "publish/VeeamHealthCheck-$version.zip"
         $apiKey = "${{ secrets.VIRUSTOTAL_API_KEY }}"
         $headers = @{ "x-apikey" = $apiKey }
-        $form = @{ file = Get-Item $zipPath }
+        $fileSizeMB = [math]::Round((Get-Item $zipPath).Length / 1MB, 1)
 
         try {
-          $uploadResponse = Invoke-RestMethod -Uri "https://www.virustotal.com/api/v3/files" -Method Post -Headers $headers -Form $form
+          # Files >32 MB require the large-file upload URL (VT premium endpoint)
+          $uploadUri = "https://www.virustotal.com/api/v3/files"
+          if ($fileSizeMB -gt 32) {
+            Write-Host "File is $fileSizeMB MB — requesting large-file upload URL..."
+            $urlResp = Invoke-RestMethod -Uri "https://www.virustotal.com/api/v3/files/upload_url" -Headers $headers
+            $uploadUri = $urlResp.data
+            Write-Host "Got large-file upload URL"
+          }
+          $uploadResponse = Invoke-RestMethod -Uri $uploadUri -Method Post -Headers $headers -Form @{ file = Get-Item $zipPath }
           $analysisId = $uploadResponse.data.id
-          Write-Host "Uploaded to VirusTotal. Analysis ID: $analysisId"
+          Write-Host "Uploaded to VirusTotal ($fileSizeMB MB). Analysis ID: $analysisId"
 
           $maxAttempts = 20
           $attempt = 0

--- a/vHC/HC_Reporting/Functions/Reporting/CsvHandlers/CCsvParser.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/CsvHandlers/CCsvParser.cs
@@ -600,6 +600,60 @@ namespace VeeamHealthCheck.Functions.Reporting.CsvHandlers
             return Enumerable.Empty<CBnRCsvInfo>();
         }
 
+        // The canonical VBR-info CSV suffix. Collection writes every CSV as
+        // "{vbrServerName}_{token}.csv" and the containing folder is also named after the
+        // VBR server (see CVariables.GetVbrDirWithTimestamp). The filename prefix is therefore
+        // the authoritative VBR server name for BOTH live runs and imports — and, unlike the
+        // PgHost/MsHost columns inside vbrinfo.csv, it is immune to the database living on a
+        // separate host (issue #158).
+        private const string VbrInfoCsvSuffix = "_vbrinfo.csv";
+
+        /// <summary>
+        /// Extracts the VBR server name from a collected CSV file name of the form
+        /// "{server}_vbrinfo.csv" (e.g. "vbr-v13-rtm.home.lab_vbrinfo.csv" -> "vbr-v13-rtm.home.lab").
+        /// Anchors on the known "_vbrinfo.csv" suffix so server names containing dots (FQDNs) are
+        /// preserved and tokens that themselves contain underscores cannot corrupt the result.
+        /// Returns null when the name does not match the expected pattern.
+        /// </summary>
+        public static string ExtractServerNameFromCsvFileName(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+                return null;
+
+            fileName = Path.GetFileName(fileName);
+            if (!fileName.EndsWith(VbrInfoCsvSuffix, StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            string server = fileName.Substring(0, fileName.Length - VbrInfoCsvSuffix.Length);
+            return string.IsNullOrWhiteSpace(server) ? null : server;
+        }
+
+        /// <summary>
+        /// Resolves the VBR server name by locating the "{server}_vbrinfo.csv" file beneath the
+        /// supplied collection directory and reading its filename prefix. This is the source of
+        /// truth for report naming because collection itself derived the same name when it wrote
+        /// the folder/files. Works for live and imported datasets alike. Returns null when no
+        /// vbrinfo CSV is present or the directory does not exist.
+        /// </summary>
+        public static string ResolveServerNameFromCsvDir(string csvDirectory)
+        {
+            if (string.IsNullOrEmpty(csvDirectory) || !Directory.Exists(csvDirectory))
+                return null;
+
+            try
+            {
+                string match = Directory
+                    .EnumerateFiles(csvDirectory, "*" + VbrInfoCsvSuffix, SearchOption.AllDirectories)
+                    .FirstOrDefault();
+
+                return match == null ? null : ExtractServerNameFromCsvFileName(match);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
         public IEnumerable<CSobrExtentCsvInfos> SobrExtParser()
         {
             this.log.Info($"[CCsvParser] Looking for SOBR Extent CSV file: {this.sobrExtReportName}");

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -340,6 +340,20 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                     }
                 }
 
+                // physProtNames was never populated, so the Protected Workloads summary always
+                // rendered "Phy Protected = 0" and undercounted "Phys Total" (it only saw the
+                // not-protected list). Populate it from the protected agents so the counters --
+                // physTotal = physProtNames + physNotProtNames, physProtected = physProtNames --
+                // reflect reality. (Renderer-side companion to the #125 collection fix.)
+                foreach (var p in physProtected)
+                {
+                    if (p.type == "Computer")
+                    {
+                        physNames.Add(p.name);
+                        physProtNames.Add(p.name);
+                    }
+                }
+
                 List<string> vmProtectedByPhys = new();
                 foreach (var p in physProtected)
                 {

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlBodyHelper.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlBodyHelper.cs
@@ -68,15 +68,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR
             this.log.Info(this.logStart + "Generating Configuration Tables section...");
             this.ConfigurationTablesSection();
             this.log.Info(this.logStart + "Configuration Tables section completed.");
-            
-            this.log.Info(this.logStart + "Generating General Settings section...");
-            this.GeneralSettingsSection();
-            this.log.Info(this.logStart + "General Settings section completed.");
-            
-            this.log.Info(this.logStart + "Generating RegistryKeyTable...");
-            this.RegistryKeyTable();
-            this.log.Info(this.logStart + "RegistryKeyTable completed.");
-            
+
             this.log.Info(this.logStart + "Generating Proxy Info section...");
             this.ProxyInfoSection();
             this.log.Info(this.logStart + "Proxy Info section completed.");
@@ -92,6 +84,20 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR
             this.log.Info(this.logStart + "Generating Job Tables section...");
             this.JobTablesSection();
             this.log.Info(this.logStart + "Job Tables section completed.");
+
+            // General Settings (credentials/roles/email) and Registry Keys are
+            // reference/appendix material. Emit them after the job tables so the body
+            // flows Overview -> Infrastructure -> Cloud -> Jobs -> Misc, matching the
+            // sidebar grouping; Registry Keys map to the sidebar "Misc" group, which is
+            // last (issue #146). Previously these sat between Configuration Tables and
+            // Proxy Info, interrupting the Infrastructure -> Cloud -> Jobs flow.
+            this.log.Info(this.logStart + "Generating General Settings section...");
+            this.GeneralSettingsSection();
+            this.log.Info(this.logStart + "General Settings section completed.");
+
+            this.log.Info(this.logStart + "Generating RegistryKeyTable...");
+            this.RegistryKeyTable();
+            this.log.Info(this.logStart + "RegistryKeyTable completed.");
 
             if (CGlobals.EXPORTINDIVIDUALJOBHTMLS)
             {

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlBodyHelper.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlBodyHelper.cs
@@ -226,6 +226,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR
             this.HTMLSTRING += this.tables.AddCloudConnectHeader();
             this.CloudGatewaysTable();
             this.CloudGatewayPoolsTable();
+            this.CloudTenantPerformanceTable();
             this.CloudTenantsTable();
             this.CloudTenantBackupResourcesTable();
             this.CloudTenantReplicationResourcesTable();
@@ -245,6 +246,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR
         private void CloudGatewayPoolsTable()
         {
             this.HTMLSTRING += this.tables.AddCloudGatewayPoolsTable(this.SCRUB);
+        }
+
+        private void CloudTenantPerformanceTable()
+        {
+            this.HTMLSTRING += this.tables.AddCloudTenantPerformanceTable(this.SCRUB);
         }
 
         private void CloudTenantsTable()

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlCompiler.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlCompiler.cs
@@ -130,51 +130,39 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR
                 return CGlobals.REMOTEHOST;
             }
 
-            // Priority 2: Extract VBR server name from vbrinfo CSV (works for import and local)
+            // Priority 2: Derive the VBR server name from the collected CSV file names.
+            // Collection writes "{vbrServerName}_{token}.csv" under Original\VBR\{vbrServerName}\{timestamp},
+            // so the filename prefix is the authoritative VBR server name for both live and imported
+            // datasets. Unlike the PgHost/MsHost columns inside vbrinfo.csv, this stays correct even
+            // when the configuration database lives on a separate host (issue #158).
             try
             {
-                this.log.Info(this.logStart + "Attempting to read VBR server name from vbrinfo.csv...");
-                CCsvParser parser = new();
-                var vbrInfo = parser.BnrCsvParser()?.FirstOrDefault();
+                this.log.Info(this.logStart + "Resolving VBR server name from collected CSV file names...");
+                string csvDir = new CCsvParser().outPath;
+                string serverName = CCsvParser.ResolveServerNameFromCsvDir(csvDir);
 
-                if (vbrInfo != null)
+                if (!string.IsNullOrEmpty(serverName))
                 {
-                    // Determine server name based on database type
-                    string serverName = null;
-
-                    if (!string.IsNullOrEmpty(vbrInfo.DbType))
-                    {
-                        if (vbrInfo.DbType.Equals("PostgreSQL", StringComparison.OrdinalIgnoreCase) ||
-                            vbrInfo.DbType.Equals("PostgreSql", StringComparison.OrdinalIgnoreCase))
-                        {
-                            serverName = vbrInfo.PgHost;
-                            this.log.Info(this.logStart + "Using PostgreSQL host: " + serverName);
-                        }
-                        else if (vbrInfo.DbType.Contains("Sql", StringComparison.OrdinalIgnoreCase))
-                        {
-                            serverName = vbrInfo.MsHost;
-                            this.log.Info(this.logStart + "Using SQL Server host: " + serverName);
-                        }
-                    }
-
-                    // If we got a valid server name, use it
-                    if (!string.IsNullOrEmpty(serverName))
-                    {
-                        this.log.Info(this.logStart + "VBR server name from CSV: " + serverName);
-                        return serverName;
-                    }
+                    this.log.Info(this.logStart + "VBR server name from CSV path: " + serverName);
+                    return serverName;
                 }
-                else
-                {
-                    this.log.Warning(this.logStart + "vbrinfo.csv not found or empty");
-                }
+
+                this.log.Warning(this.logStart + "No vbrinfo CSV found under: " + csvDir);
             }
             catch (Exception ex)
             {
-                this.log.Warning(this.logStart + "Failed to read VBR server name from CSV: " + ex.Message);
+                this.log.Warning(this.logStart + "Failed to resolve VBR server name from CSV path: " + ex.Message);
             }
 
-            // Priority 3: Fallback to local hostname
+            // Priority 3: GUI-selected server name, when it is something other than the localhost default.
+            if (!string.IsNullOrEmpty(CGlobals.VBRServerName) &&
+                !CGlobals.VBRServerName.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                this.log.Info(this.logStart + "Using CGlobals.VBRServerName: " + CGlobals.VBRServerName);
+                return CGlobals.VBRServerName;
+            }
+
+            // Priority 4: Fallback to local hostname
             this.log.Info(this.logStart + "Falling back to Dns.GetHostName()...");
             string hostname = Dns.GetHostName();
             this.log.Info(this.logStart + "Using local hostname: " + hostname);

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlCompiler.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/CHtmlCompiler.cs
@@ -515,6 +515,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR
                 nav += this.form.NavSection("Cloud Connect",
                     this.form.NavLink("cloudgateways", "Gateways") +
                     this.form.NavLink("cloudgatewaypools", "Gateway Pools") +
+                    this.form.NavLink("cloudtenantperf", "Tenant Performance") +
                     this.form.NavLink("cloudtenants", "Tenants") +
                     this.form.NavLink("cloudtenantbackup", "Tenant Backup Storage") +
                     this.form.NavLink("cloudtenantreplica", "Tenant Replica Resources") +

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
@@ -1503,6 +1503,12 @@ namespace VeeamHealthCheck.Html.VBR
             return table.Render(scrub);
         }
 
+        public string AddCloudTenantPerformanceTable(bool scrub)
+        {
+            var table = new CCloudTenantPerformanceTable();
+            return table.Render(scrub);
+        }
+
         public string AddCloudTenantsTable(bool scrub)
         {
             var table = new CCloudTenantsTable();

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudConnectHelpers.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudConnectHelpers.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
+{
+    internal static class CCloudConnectHelpers
+    {
+        internal static string FormatMaxConcurrent(string raw) =>
+            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
+
+        internal static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
+            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
+             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
+                ? "—" : fieldValue;
+    }
+}

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTable.cs
@@ -80,7 +80,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
                         if (!string.IsNullOrEmpty(hostName) && serverLookup.TryGetValue(hostName, out var srvInfo))
                         {
                             cores = srvInfo.Cores;
-                            ram = srvInfo.Ram;
+                            ram = FormatRamGb(srvInfo.Ram);
                         }
                         s += this.form.TableData(cores, string.Empty);
                         s += this.form.TableData(ram, string.Empty);
@@ -98,6 +98,15 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             s += this.form.SectionEnd();
 
             return s;
+        }
+
+        private static string FormatRamGb(string rawBytes)
+        {
+            if (string.IsNullOrWhiteSpace(rawBytes)) return string.Empty;
+            if (!long.TryParse(rawBytes.Trim(), System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out long bytes)) return rawBytes;
+            long gb = (long)System.Math.Round(bytes / (1024d * 1024d * 1024d));
+            return $"{gb} GB";
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTable.cs
@@ -54,10 +54,10 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
 
                         s += this.form.TableDataLeftAligned(name, string.Empty);
                         s += this.form.TableData((string)(item.enabled ?? ""), string.Empty);
-                        s += this.form.TableData(FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
                         s += this.form.TableData(throttlingEnabled, string.Empty);
-                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
-                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
 
                         s += "</tr>";
                     }
@@ -73,12 +73,5 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             return s;
         }
 
-        private static string FormatMaxConcurrent(string raw) =>
-            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
-
-        private static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
-            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
-             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
-                ? "—" : fieldValue;
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTable.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using System.Linq;
+using VeeamHealthCheck.Functions.Reporting.CsvHandlers;
+using VeeamHealthCheck.Functions.Reporting.Html.Shared;
+using VeeamHealthCheck.Scrubber;
+using VeeamHealthCheck.Shared;
+
+namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
+{
+    internal class CCloudTenantPerformanceTable
+    {
+        private readonly CHtmlFormatting form = new();
+
+        public CCloudTenantPerformanceTable() { }
+
+        public string Render(bool scrub)
+        {
+            string s = this.form.SectionStartWithButton("cloudtenantperf", "Tenant Performance Settings", "Tenant Performance Settings");
+
+            s += this.form.TableHeaderLeftAligned("Tenant", string.Empty);
+            s += this.form.TableHeader("Enabled", string.Empty);
+            s += this.form.TableHeader("Max Concurrent Tasks", string.Empty);
+            s += this.form.TableHeader("Bandwidth Throttling", string.Empty);
+            s += this.form.TableHeader("Max Bandwidth", string.Empty);
+            s += this.form.TableHeader("Bandwidth Unit", string.Empty);
+
+            s += this.form.TableHeaderEnd();
+            s += this.form.TableBodyStart();
+
+            try
+            {
+                CCsvParser c = new();
+                var data = c.GetDynamicCloudTenants().ToList();
+
+                if (!data.Any())
+                {
+                    s += "<tr><td colspan='6' style='text-align: center; padding: 20px; color: #666;'><em>No cloud tenants detected.</em></td></tr>";
+                }
+                else
+                {
+                    foreach (var item in data)
+                    {
+                        s += "<tr>";
+
+                        string name = (string)(item.name ?? "");
+                        if (scrub)
+                        {
+                            name = CGlobals.Scrubber.ScrubItem(name, ScrubItemType.Item);
+                        }
+
+                        string throttlingEnabled = (string)(item.throttlingenabled ?? "");
+
+                        s += this.form.TableDataLeftAligned(name, string.Empty);
+                        s += this.form.TableData((string)(item.enabled ?? ""), string.Empty);
+                        s += this.form.TableData(FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
+                        s += this.form.TableData(throttlingEnabled, string.Empty);
+                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
+                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
+
+                        s += "</tr>";
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                CGlobals.Logger.Error("Failed to render Cloud Tenant Performance table: " + e.Message);
+            }
+
+            s += this.form.SectionEnd();
+
+            return s;
+        }
+
+        private static string FormatMaxConcurrent(string raw) =>
+            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
+
+        private static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
+            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
+             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
+                ? "—" : fieldValue;
+    }
+}

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTable.cs
@@ -37,8 +37,8 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             s += this.form.TableHeader("Rental Replicas", string.Empty);
             s += this.form.TableHeader("Max Concurrent Tasks", string.Empty);
             s += this.form.TableHeader("Throttling Enabled", string.Empty);
-            s += this.form.TableHeader("Throttle Value", string.Empty);
-            s += this.form.TableHeader("Throttle Unit", string.Empty);
+            s += this.form.TableHeader("Max Bandwidth", string.Empty);
+            s += this.form.TableHeader("Bandwidth Unit", string.Empty);
             s += this.form.TableHeader("Gateway Selection", string.Empty);
             s += this.form.TableHeader("Gateway Pool", string.Empty);
             s += this.form.TableHeader("Gateway Failover", string.Empty);
@@ -93,10 +93,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
                         s += this.form.TableData((string)(item.rentalserverbackupcount ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.rentalworkstationbackupcount ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.rentalreplicacount ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.maxconcurrenttask ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.throttlingenabled ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.throttlingvalue ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.throttlingunit ?? ""), string.Empty);
+                        s += this.form.TableData(FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
+                        string throttlingEnabled = (string)(item.throttlingenabled ?? "");
+                        s += this.form.TableData(throttlingEnabled, string.Empty);
+                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
+                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
                         s += this.form.TableData((string)(item.gatewayselectiontype ?? ""), string.Empty);
                         s += this.form.TableData(gatewayPoolName, string.Empty);
                         s += this.form.TableData((string)(item.gatewayfailoverenabled ?? ""), string.Empty);
@@ -118,5 +119,13 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
 
             return s;
         }
+
+        private static string FormatMaxConcurrent(string raw) =>
+            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
+
+        private static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
+            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
+             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
+                ? "—" : fieldValue;
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTable.cs
@@ -93,11 +93,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
                         s += this.form.TableData((string)(item.rentalserverbackupcount ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.rentalworkstationbackupcount ?? ""), string.Empty);
                         s += this.form.TableData((string)(item.rentalreplicacount ?? ""), string.Empty);
-                        s += this.form.TableData(FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatMaxConcurrent((string)(item.maxconcurrenttask ?? "")), string.Empty);
                         string throttlingEnabled = (string)(item.throttlingenabled ?? "");
                         s += this.form.TableData(throttlingEnabled, string.Empty);
-                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
-                        s += this.form.TableData(FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatThrottleField(throttlingEnabled, (string)(item.throttlingvalue ?? "")), string.Empty);
+                        s += this.form.TableData(CCloudConnectHelpers.FormatThrottleField(throttlingEnabled, (string)(item.throttlingunit ?? "")), string.Empty);
                         s += this.form.TableData((string)(item.gatewayselectiontype ?? ""), string.Empty);
                         s += this.form.TableData(gatewayPoolName, string.Empty);
                         s += this.form.TableData((string)(item.gatewayfailoverenabled ?? ""), string.Empty);
@@ -120,12 +120,5 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             return s;
         }
 
-        private static string FormatMaxConcurrent(string raw) =>
-            (string.IsNullOrWhiteSpace(raw) || raw.Trim() == "0") ? "Unlimited" : raw;
-
-        private static string FormatThrottleField(string throttlingEnabled, string fieldValue) =>
-            (string.IsNullOrWhiteSpace(throttlingEnabled) ||
-             throttlingEnabled.Trim().Equals("False", System.StringComparison.OrdinalIgnoreCase))
-                ? "—" : fieldValue;
     }
 }

--- a/vHC/HC_Reporting/ReportScript.js
+++ b/vHC/HC_Reporting/ReportScript.js
@@ -19,12 +19,19 @@ function toggleAll() {
 }
 
 // ===== Legacy Collapsible Toggle (for sections using SectionStartWithButton) =====
+// The element a collapsible button reveals is simply whatever follows it. Historically
+// that was a <div class="content">, but the VB365 stat sections (Job Statistics,
+// Processing Stats, Job Sessions) place a bare <table> there. The old guard only
+// toggled siblings with class="content", so those tables stayed permanently collapsed
+// (issue #49). Toggle the next sibling regardless of class. Reveal by clearing the
+// inline display so each element returns to its natural value (table -> table,
+// div -> block) instead of forcing 'block', which would break <table> column layout.
 document.addEventListener('DOMContentLoaded', function() {
   document.querySelectorAll('.collapsible').forEach(function(btn) {
     btn.addEventListener('click', function() {
       var content = this.nextElementSibling;
-      if (content && content.classList.contains('content')) {
-        content.style.display = (content.style.display === 'none' || content.style.display === '') ? 'block' : 'none';
+      if (content) {
+        content.style.display = (content.style.display === 'none') ? '' : 'none';
       }
     });
   });

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcProtectedWorkloads.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcProtectedWorkloads.ps1
@@ -4,6 +4,26 @@ function Get-VhcProtectedWorkloads {
     <#
     .Synopsis
         Collects protected and unprotected workloads across VMware, Hyper-V, and physical platforms.
+
+        Protection status is resolved by partitioning the live inventory against the distinct names
+        of the most-recent restore points (OIBs) per platform. This replaces the prior
+        Find-VBR*Entity -Name <array> lookup, which:
+          * over-matched container/template nodes -- reporting MORE "protected" VMs than exist in
+            inventory (lab: 112 "protected" vs 104 total objects / 98 real VMs), and
+          * under-matched at multi-vCenter scale (customer issue #125: 11 "protected" of 2849).
+        The same array lookup also pulled the whole hierarchy tree (Datacenter/Cluster/Host/Folder
+        container nodes), not just VMs, which corrupted totals.
+
+        New approach (proven on vbr-v13-rtm.home.lab):
+          * VMware  -- inventory = Find-VBRViEntity filtered to Type 'Vm' leaf objects, de-duplicated
+                       by VM display name so a VM enumerated in multiple inventory views is counted
+                       once. (No stable OIB<->inventory id exists at the VBR API surface; name is the
+                       only available correlation, confirmed empirically against the live lab.)
+          * Hyper-V -- inventory = Find-VBRHvEntity, partitioned by name membership (symmetric with
+                       the existing unprotected logic; only the broken -Name protected lookup changes).
+          * Physical-- inventory = Get-VBRDiscoveredComputer. Agent backups expose no OIBs via
+                       GetLastOibs(), so protected names fall back to restore-point enumeration.
+
         Each platform has its own inner try/catch so a failure on one does not skip the others.
         Preserves the GetLastOibs($true) -> GetLastOibs() fallback pattern.
         Exports _PhysProtected.csv, _PhysNotProtected.csv, _HvProtected.csv,
@@ -16,34 +36,62 @@ function Get-VhcProtectedWorkloads {
     $message = "Collecting protected workloads info..."
     Write-LogFile $message
 
-    $protected             = $null
-    $notprotected          = $null
-    $protectedHvEntityInfo = $null
+    $protected               = $null
+    $notprotected            = $null
+    $protectedHvEntityInfo   = $null
     $unprotectedHvEntityInfo = $null
-    $protectedEntityInfo   = $null
-    $unprotectedEntityInfo = $null
+    $protectedEntityInfo     = $null
+    $unprotectedEntityInfo   = $null
+
+    # Returns the distinct, non-empty restore-point (OIB) names for a set of backups, as a
+    # case-insensitive HashSet for O(1) membership tests. Uses the documented
+    # GetLastOibs($true) -> GetLastOibs() fallback; when both yield nothing (agent/physical
+    # backups expose no OIBs this way) it falls back to restore-point enumeration.
+    function Get-VhcProtectedNames {
+        param($Backups)
+        $names = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+        if ($null -eq $Backups) { return , $names }
+        $oibs = $null
+        try { $oibs = $Backups.GetLastOibs($true) }
+        catch {
+            try { $oibs = $Backups.GetLastOibs() } catch { $oibs = $null }
+        }
+        foreach ($o in @($oibs)) {
+            if ($null -ne $o -and $o.Name) { [void]$names.Add([string]$o.Name) }
+        }
+        if ($names.Count -eq 0) {
+            foreach ($b in @($Backups)) {
+                try {
+                    foreach ($rp in @(Get-VBRRestorePoint -Backup $b)) {
+                        if ($rp.Name) { [void]$names.Add([string]$rp.Name) }
+                    }
+                }
+                catch {}
+            }
+        }
+        return , $names
+    }
 
     # VMware workloads
     try {
-        $vmbackups = Get-VBRBackup | Where-Object { $_.TypeToString -eq "VMware Backup" }
+        $vmbackups      = Get-VBRBackup | Where-Object { $_.TypeToString -eq "VMware Backup" }
+        $protectedNames = Get-VhcProtectedNames -Backups $vmbackups
 
-        try {
-            $vmNames = $vmbackups.GetLastOibs($true)
-        }
-        catch {
-            try {
-                $vmNames = $vmbackups.GetLastOibs()
-            }
-            catch {}
-        }
+        # VM leaf objects only (Type 'Vm') -- excludes Datacenter/Cluster/Host/Folder container
+        # nodes that Find-VBRViEntity otherwise returns and that previously corrupted totals.
+        # De-duplicate by VM display name so a VM enumerated in multiple inventory views collapses
+        # to one workload row (the multi-vCenter duplication behind #125).
+        # NOTE: Veeam exposes no stable id linking a restore point (OIB) to an inventory VM -- name
+        # is the only available correlation -- so protection status is name-resolved, and the
+        # inventory is name-keyed to keep protected/unprotected internally consistent. In the rare
+        # case where genuinely distinct VMs share a display name, they count as one workload.
+        $viInventory = Find-VBRViEntity |
+            Where-Object { "$($_.Type)" -eq 'Vm' } |
+            Group-Object { [string]$_.Name } |
+            ForEach-Object { $_.Group[0] }
 
-        $unprotectedEntityInfo = Find-VBRViEntity | Where-Object { $_.Name -notin $vmNames.Name }
-        if ($null -eq $vmNames -or $null -eq $vmNames.Name) {
-            $protectedEntityInfo = Find-VBRViEntity -Name " "
-        }
-        else {
-            $protectedEntityInfo = Find-VBRViEntity -Name $vmNames.Name
-        }
+        $protectedEntityInfo   = $viInventory | Where-Object { $protectedNames.Contains([string]$_.Name) }
+        $unprotectedEntityInfo = $viInventory | Where-Object { -not $protectedNames.Contains([string]$_.Name) }
     }
     catch {
         Write-LogFile "Failed on VMware workloads: $($_.Exception.Message)" -LogLevel "ERROR"
@@ -52,25 +100,15 @@ function Get-VhcProtectedWorkloads {
 
     # Hyper-V workloads
     try {
-        $hvvmbackups = Get-VBRBackup | Where-Object { $_.TypeToString -eq "Hyper-v Backup" }
+        $hvvmbackups      = Get-VBRBackup | Where-Object { $_.TypeToString -eq "Hyper-v Backup" }
+        $hvProtectedNames = Get-VhcProtectedNames -Backups $hvvmbackups
 
-        try {
-            $hvvmNames = $hvvmbackups.GetLastOibs($true)
-        }
-        catch {
-            try {
-                $hvvmNames = $hvvmbackups.GetLastOibs()
-            }
-            catch {}
-        }
+        # Partition a single Find-VBRHvEntity enumeration by name membership -- symmetric protected
+        # / unprotected, replacing the broken Find-VBRHvEntity -Name <array> protected lookup.
+        $hvInventory = @(Find-VBRHvEntity)
 
-        $unprotectedHvEntityInfo = Find-VBRHvEntity | Where-Object { $_.Name -notin $hvvmNames.Name }
-        if ($null -eq $hvvmNames.Name) {
-            $protectedHvEntityInfo = Find-VBRHvEntity -Name " "
-        }
-        else {
-            $protectedHvEntityInfo = Find-VBRHvEntity -Name $hvvmNames.Name
-        }
+        $protectedHvEntityInfo   = $hvInventory | Where-Object { $hvProtectedNames.Contains([string]$_.Name) }
+        $unprotectedHvEntityInfo = $hvInventory | Where-Object { -not $hvProtectedNames.Contains([string]$_.Name) }
     }
     catch {
         Write-LogFile "Failed on Hyper-V workloads: $($_.Exception.Message)" -LogLevel "ERROR"
@@ -79,22 +117,12 @@ function Get-VhcProtectedWorkloads {
 
     # Physical workloads
     try {
-        $phys = Get-VBRDiscoveredComputer
+        $phys               = Get-VBRDiscoveredComputer
+        $physbackups        = Get-VBRBackup | Where-Object { $_.TypeToString -like "*Agent*" }
+        $physProtectedNames = Get-VhcProtectedNames -Backups $physbackups
 
-        $physbackups = Get-VBRBackup | Where-Object { $_.TypeToString -like "*Agent*" }
-
-        try {
-            $pvmNames = $physbackups.GetLastOibs($true)
-        }
-        catch {
-            try {
-                $pvmNames = $physbackups.GetLastOibs()
-            }
-            catch {}
-        }
-
-        $notprotected = $phys | Where-Object { $_.Name -notin $pvmNames.Name }
-        $protected    = $phys | Where-Object { $_.Name -in $pvmNames.Name }
+        $protected    = $phys | Where-Object { $physProtectedNames.Contains([string]$_.Name) }
+        $notprotected = $phys | Where-Object { -not $physProtectedNames.Contains([string]$_.Name) }
     }
     catch {
         Write-LogFile "Failed on physical workloads: $($_.Exception.Message)" -LogLevel "ERROR"

--- a/vHC/HC_Reporting/css.css
+++ b/vHC/HC_Reporting/css.css
@@ -278,7 +278,11 @@ body {
   overflow-x: auto;
 }
 
-.section-card.open .section-body {
+/* Direct-child combinator so a card's "open" state controls ONLY its own
+   immediate body. With the previous descendant selector, an open parent section
+   (e.g. Job Info) forced every nested subsection body visible, so subsections
+   could never be collapsed independently (issue #145). */
+.section-card.open > .section-body {
   display: block;
 }
 

--- a/vHC/VhcXTests/Functions/Reporting/CsvHandlers/CCsvParserServerNameTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/CsvHandlers/CCsvParserServerNameTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using System.IO;
+using VeeamHealthCheck.Functions.Reporting.CsvHandlers;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.CsvHandlers
+{
+    /// <summary>
+    /// Regression coverage for issue #158: the report file must be named after the VBR server,
+    /// never the configuration-database host. The authoritative server name is the prefix of the
+    /// collected "{server}_vbrinfo.csv" file (and the folder it lives in), which collection derived
+    /// from the real VBR server name. The previous implementation read PgHost/MsHost from inside
+    /// vbrinfo.csv, which is the database host and is wrong whenever DB and VBR are separate machines.
+    /// </summary>
+    [Trait("Category", "CsvParsing")]
+    public class CCsvParserServerNameTests : IDisposable
+    {
+        private readonly string _root;
+
+        public CCsvParserServerNameTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "VhcServerNameTests_" + Guid.NewGuid());
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+        }
+
+        [Theory]
+        [InlineData("vbr-v13-rtm.home.lab_vbrinfo.csv", "vbr-v13-rtm.home.lab")]
+        [InlineData("backup-prod-01_vbrinfo.csv", "backup-prod-01")]
+        [InlineData(@"C:\temp\vHC\Original\VBR\vbr01.contoso.com\20260101_000000\vbr01.contoso.com_vbrinfo.csv", "vbr01.contoso.com")]
+        public void ExtractServerName_ReturnsFqdnPrefix(string fileName, string expected)
+        {
+            Assert.Equal(expected, CCsvParser.ExtractServerNameFromCsvFileName(fileName));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("vbrinfo.csv")]                 // no server prefix
+        [InlineData("server_Servers.csv")]          // different token
+        [InlineData("server_malware_events.csv")]   // token with underscores must not be mis-parsed
+        public void ExtractServerName_ReturnsNull_ForNonMatching(string fileName)
+        {
+            Assert.Null(CCsvParser.ExtractServerNameFromCsvFileName(fileName));
+        }
+
+        [Fact]
+        public void ResolveServerNameFromCsvDir_ReturnsNull_WhenDirMissing()
+        {
+            Assert.Null(CCsvParser.ResolveServerNameFromCsvDir(Path.Combine(_root, "does-not-exist")));
+            Assert.Null(CCsvParser.ResolveServerNameFromCsvDir(null));
+        }
+
+        [Fact]
+        public void ResolveServerNameFromCsvDir_ReturnsNull_WhenNoVbrInfoCsv()
+        {
+            File.WriteAllText(Path.Combine(_root, "vbr01_Servers.csv"), "Name\nvbr01\n");
+            Assert.Null(CCsvParser.ResolveServerNameFromCsvDir(_root));
+        }
+
+        /// <summary>
+        /// Issue #158 core scenario: collection folder + filename are named after the VBR server
+        /// ("backup-prod-01"), while vbrinfo.csv's MsHost points at a SEPARATE database host
+        /// ("sql-db-99"). The resolver must return the VBR server name, not the database host.
+        /// </summary>
+        [Fact]
+        public void ResolveServerNameFromCsvDir_UsesVbrName_NotDatabaseHost()
+        {
+            const string vbrServer = "backup-prod-01.contoso.com";
+            const string dbHost = "sql-db-99.contoso.com";
+
+            string collectionDir = Path.Combine(_root, "Original", "VBR", vbrServer, "20260101_000000");
+            Directory.CreateDirectory(collectionDir);
+
+            // vbrinfo.csv whose database columns point at a DIFFERENT host than the VBR server.
+            string header = "\"Version\",\"Fixes\",\"SqlServer\",\"Instance\",\"PgHost\",\"PgDb\",\"MsHost\",\"MsDb\",\"DbType\",\"MFA\"";
+            string row = $"\"13.0.1.2067\",,\"{dbHost}\",,,,\"{dbHost}\",\"VeeamBackup\",\"MsSql\",\"False\"";
+            File.WriteAllText(Path.Combine(collectionDir, $"{vbrServer}_vbrinfo.csv"), header + "\n" + row + "\n");
+
+            string resolved = CCsvParser.ResolveServerNameFromCsvDir(collectionDir);
+
+            Assert.Equal(vbrServer, resolved);
+            Assert.NotEqual(dbHost, resolved);
+        }
+
+        /// <summary>
+        /// Anti-regression for ISC-9: the colocated/local case (folder named after the VBR server,
+        /// no separate DB host) still yields the same FQDN it always did.
+        /// </summary>
+        [Fact]
+        public void ResolveServerNameFromCsvDir_ColocatedCase_StillYieldsFqdn()
+        {
+            const string vbrServer = "vbr-v13-rtm.home.lab";
+            string collectionDir = Path.Combine(_root, "Original", "VBR", vbrServer, "20260529_103007");
+            Directory.CreateDirectory(collectionDir);
+            File.WriteAllText(
+                Path.Combine(collectionDir, $"{vbrServer}_vbrinfo.csv"),
+                "\"Version\",\"Fixes\",\"SqlServer\",\"Instance\",\"PgHost\",\"PgDb\",\"MsHost\",\"MsDb\",\"DbType\",\"MFA\"\n\"13.0.1.2067\",,,,,,,,,\"False\"\n");
+
+            Assert.Equal(vbrServer, CCsvParser.ResolveServerNameFromCsvDir(collectionDir));
+        }
+    }
+}

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTableTests.cs
@@ -25,10 +25,6 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
         private const string GatewayHeaders =
             "name,description,ipaddress,networkmode,incomingport,natport,hostname,enabled";
 
-        // Server CSV: 15 required columns (0–14), indices match CServerCsvInfos.
-        // Index: 0=Info, 1=ParentId, 2=Id, 3=Uid, 4=Name, 5=Reference, 6=Description,
-        //        7=IsUnavailable, 8=Type, 9=ApiVersion, 10=PhysHostId, 11=ProxyServicesCreds,
-        //        12=Cores, 13=CPU, 14=Ram
         private const string ServerHeaders =
             "Info,ParentId,Id,Uid,Name,Reference,Description,IsUnavailable,Type,ApiVersion,PhysHostId,ProxyServicesCreds,Cores,CPU,Ram";
 

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudGatewaysTableTests.cs
@@ -22,11 +22,21 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
     {
         public CCloudGatewaysTableTests() : base("VhcCloudGatewaysTests_") { }
 
-        private const string Headers =
+        private const string GatewayHeaders =
             "name,description,ipaddress,networkmode,incomingport,natport,hostname,enabled";
 
+        // Server CSV: 15 required columns (0–14), indices match CServerCsvInfos.
+        // Index: 0=Info, 1=ParentId, 2=Id, 3=Uid, 4=Name, 5=Reference, 6=Description,
+        //        7=IsUnavailable, 8=Type, 9=ApiVersion, 10=PhysHostId, 11=ProxyServicesCreds,
+        //        12=Cores, 13=CPU, 14=Ram
+        private const string ServerHeaders =
+            "Info,ParentId,Id,Uid,Name,Reference,Description,IsUnavailable,Type,ApiVersion,PhysHostId,ProxyServicesCreds,Cores,CPU,Ram";
+
         private void WriteCsv(string rows) =>
-            File.WriteAllText(Path.Combine(VbrDir, "_CloudGateways.csv"), Headers + "\n" + rows);
+            File.WriteAllText(Path.Combine(VbrDir, "_CloudGateways.csv"), GatewayHeaders + "\n" + rows);
+
+        private void WriteServerCsv(string rows) =>
+            File.WriteAllText(Path.Combine(VbrDir, "_Servers.csv"), ServerHeaders + "\n" + rows);
 
         [Fact]
         public void Render_NoData_ShowsEmptyStateMessage()
@@ -59,6 +69,44 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             Assert.DoesNotContain("ACME-Gateway", html);
             Assert.DoesNotContain("acme.corp", html);
             // non-PII column still renders
+            Assert.Contains("DirectMode", html);
+        }
+
+        [Fact]
+        public void Render_ServerRamPresent_DisplaysGigabytes()
+        {
+            // 410665353216 bytes = 382.something GB → rounds to 382
+            WriteCsv("ACME-Gateway,Edge gateway,203.0.113.10,DirectMode,6180,33,gw-host01,True");
+            WriteServerCsv("info1,parentid1,id1,uid1,gw-host01,ref1,desc1,False,Windows,12,physid1,creds1,32,Intel Xeon,410665353216");
+
+            string html = new CCloudGatewaysTable().Render(scrub: false);
+
+            Assert.Contains("382 GB", html);
+            Assert.DoesNotContain("410665353216", html);
+        }
+
+        [Fact]
+        public void Render_ServerRamUnparseable_DisplaysRawValue()
+        {
+            WriteCsv("ACME-Gateway,Edge gateway,203.0.113.10,DirectMode,6180,33,gw-host01,True");
+            WriteServerCsv("info1,parentid1,id1,uid1,gw-host01,ref1,desc1,False,Windows,12,physid1,creds1,32,Intel Xeon,not-a-number");
+
+            string html = new CCloudGatewaysTable().Render(scrub: false);
+
+            Assert.Contains("not-a-number", html);
+        }
+
+        [Fact]
+        public void Render_ServerRamEmpty_RendersWithoutCrash()
+        {
+            WriteCsv("ACME-Gateway,Edge gateway,203.0.113.10,DirectMode,6180,33,gw-host01,True");
+            WriteServerCsv("info1,parentid1,id1,uid1,gw-host01,ref1,desc1,False,Windows,12,physid1,creds1,32,Intel Xeon,");
+
+            // Should not throw; no raw bytes string in output
+            string html = new CCloudGatewaysTable().Render(scrub: false);
+
+            Assert.DoesNotContain("No cloud gateways detected", html);
+            // Empty RAM — just verify the row rendered and no byte-style number leaked
             Assert.Contains("DirectMode", html);
         }
     }

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTableTests.cs
@@ -7,21 +7,11 @@ using Xunit;
 
 namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
 {
-    /// <summary>
-    /// Characterization tests for the Cloud Connect "Tenant Performance Settings" renderer.
-    /// Reuses VbrTableScrubTestBase so the renderer's CCsvParser reads our sample
-    /// _CloudTenants.csv instead of live VBR output.
-    ///
-    /// The table reads the same _CloudTenants.csv as CCloudTenantsTable; it renders
-    /// only the performance-relevant columns (6 columns total).
-    /// Scrubbed PII field: name only.
-    /// </summary>
     [Collection("GlobalState")]
     public class CCloudTenantPerformanceTableTests : VbrTableScrubTestBase
     {
         public CCloudTenantPerformanceTableTests() : base("VhcCloudTenantPerfTests_") { }
 
-        // Same 29-column header as CCloudTenantsTable — the renderer reads the same CSV file.
         private const string Headers =
             "name,description,enabled,type,lastactive,lastresult,vmcount,servercount,workstationcount,replicacount," +
             "newvmbackupcount,newserverbackupcount,newworkstationbackupcount,newreplicacount," +

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantPerformanceTableTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System.IO;
+using VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.CloudConnect;
+using VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
+{
+    /// <summary>
+    /// Characterization tests for the Cloud Connect "Tenant Performance Settings" renderer.
+    /// Reuses VbrTableScrubTestBase so the renderer's CCsvParser reads our sample
+    /// _CloudTenants.csv instead of live VBR output.
+    ///
+    /// The table reads the same _CloudTenants.csv as CCloudTenantsTable; it renders
+    /// only the performance-relevant columns (6 columns total).
+    /// Scrubbed PII field: name only.
+    /// </summary>
+    [Collection("GlobalState")]
+    public class CCloudTenantPerformanceTableTests : VbrTableScrubTestBase
+    {
+        public CCloudTenantPerformanceTableTests() : base("VhcCloudTenantPerfTests_") { }
+
+        // Same 29-column header as CCloudTenantsTable — the renderer reads the same CSV file.
+        private const string Headers =
+            "name,description,enabled,type,lastactive,lastresult,vmcount,servercount,workstationcount,replicacount," +
+            "newvmbackupcount,newserverbackupcount,newworkstationbackupcount,newreplicacount," +
+            "rentalvmbackupcount,rentalserverbackupcount,rentalworkstationbackupcount,rentalreplicacount," +
+            "maxconcurrenttask,throttlingenabled,throttlingvalue,throttlingunit,gatewayselectiontype," +
+            "gatewaypoolname,gatewayfailoverenabled,leaseexpirationenabled,leaseexpirationdate," +
+            "backupprotectionenabled,backupprotectionperiod";
+
+        private void WriteCsv(string rows) =>
+            File.WriteAllText(Path.Combine(VbrDir, "_CloudTenants.csv"), Headers + "\n" + rows);
+
+        [Fact]
+        public void Render_NoData_ShowsEmptyStateMessage()
+        {
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+            Assert.Contains("No cloud tenants detected", html);
+        }
+
+        [Fact]
+        public void Render_ColumnHeaders_ContainsAllSixHeaders()
+        {
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("Tenant", html);
+            Assert.Contains("Enabled", html);
+            Assert.Contains("Max Concurrent Tasks", html);
+            Assert.Contains("Bandwidth Throttling", html);
+            Assert.Contains("Max Bandwidth", html);
+            Assert.Contains("Bandwidth Unit", html);
+        }
+
+        [Fact]
+        public void Render_SectionId_ContainsCloudTenantPerfAnchor()
+        {
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("cloudtenantperf", html);
+        }
+
+        [Fact]
+        public void Render_MaxConcurrentTaskZero_DisplaysUnlimited()
+        {
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,0,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("Unlimited", html);
+        }
+
+        [Fact]
+        public void Render_MaxConcurrentTaskPositive_DisplaysNumericValue()
+        {
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,8,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("8", html);
+            Assert.DoesNotContain("Unlimited", html);
+        }
+
+        [Fact]
+        public void Render_ThrottlingDisabled_DisplaysDashForValueAndUnit()
+        {
+            // ThrottlingEnabled=False → value and unit render as "—"
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,4,False,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("—", html);
+            Assert.DoesNotContain("500", html);
+            Assert.DoesNotContain("MbytePerSec", html);
+        }
+
+        [Fact]
+        public void Render_ThrottlingEnabled_DisplaysValueAndUnit()
+        {
+            // ThrottlingEnabled=True → value and unit render as actual values
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,4,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: false);
+
+            Assert.Contains("500", html);
+            Assert.Contains("MbytePerSec", html);
+        }
+
+        [Fact]
+        public void Render_ScrubTrue_AnonymizesTenantNameOnly()
+        {
+            // Name is scrubbed; numeric MCT value (8) must still appear
+            WriteCsv("SECRET-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,8,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantPerformanceTable().Render(scrub: true);
+
+            Assert.DoesNotContain("SECRET-Tenant", html);
+            // MCT is a numeric field, not scrubbed
+            Assert.Contains("8", html);
+        }
+    }
+}

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTableTests.cs
@@ -43,8 +43,6 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
         [Fact]
         public void Render_ScrubFalse_RendersRawValues()
         {
-            // ThrottlingEnabled=False → value/unit render as "—" (new behavior).
-            // This test verifies the tenant name, description and non-throttle fields only.
             WriteCsv("ACME-Tenant,Production tenant for acme.corp,True,Standalone,2026-01-01,Success,12,3,4,2," +
                      "1,0,0,0,5,1,0,0,4,False,0,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
                      "2030-01-01,True,30");

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/CloudConnect/CCloudTenantsTableTests.cs
@@ -43,6 +43,8 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
         [Fact]
         public void Render_ScrubFalse_RendersRawValues()
         {
+            // ThrottlingEnabled=False → value/unit render as "—" (new behavior).
+            // This test verifies the tenant name, description and non-throttle fields only.
             WriteCsv("ACME-Tenant,Production tenant for acme.corp,True,Standalone,2026-01-01,Success,12,3,4,2," +
                      "1,0,0,0,5,1,0,0,4,False,0,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
                      "2030-01-01,True,30");
@@ -69,6 +71,70 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.CloudConnect
             Assert.DoesNotContain("acme.corp", html);
             // non-PII column still renders
             Assert.Contains("Standalone", html);
+        }
+
+        [Fact]
+        public void Render_MaxConcurrentTaskZero_DisplaysUnlimited()
+        {
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,0,False,0,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("Unlimited", html);
+        }
+
+        [Fact]
+        public void Render_MaxConcurrentTaskEmpty_DisplaysUnlimited()
+        {
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,,False,0,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("Unlimited", html);
+        }
+
+        [Fact]
+        public void Render_ThrottlingDisabled_DisplaysDashForValueAndUnit()
+        {
+            // ThrottlingEnabled=False → value and unit should show "—", not the raw values
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,4,False,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("—", html);
+            Assert.DoesNotContain("500", html);
+            Assert.DoesNotContain("MbytePerSec", html);
+        }
+
+        [Fact]
+        public void Render_ThrottlingEnabled_DisplaysActualValues()
+        {
+            // ThrottlingEnabled=True → value and unit should show actual values
+            WriteCsv("ACME-Tenant,desc,True,Standalone,2026-01-01,Success,0,0,0,0," +
+                     "0,0,0,0,0,0,0,0,4,True,500,MbytePerSec,StandaloneGateways,ACME-Pool,False,Never," +
+                     "2030-01-01,True,30");
+
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("500", html);
+            Assert.Contains("MbytePerSec", html);
+        }
+
+        [Fact]
+        public void Render_Headers_ContainsMaxBandwidthAndBandwidthUnit()
+        {
+            string html = new CCloudTenantsTable().Render(scrub: false);
+
+            Assert.Contains("Max Bandwidth", html);
+            Assert.Contains("Bandwidth Unit", html);
+            Assert.DoesNotContain("Throttle Value", html);
+            Assert.DoesNotContain("Throttle Unit", html);
         }
     }
 }


### PR DESCRIPTION
## Summary

Promotes the current `dev` line to `master`: **17 commits** covering five issues, the Cloud Connect display improvements, and release/CI tooling hardening.

## Product / report fixes

| Issue | Fix | Commit |
|-------|-----|--------|
| #125 | Protected Workloads: correct VMware protected count (was an impossible 112 > inventory; now name-set-membership over a de-duplicated VM-only inventory) **and** physical protected count (renderer never populated `physProtNames`, so it always showed 0) | `fe1849b` |
| #158 | Report is named after the VBR server, not the configuration-database host | `cf83c58` |
| #146 | Report body order now follows the sidebar / navigation grouping | `730b251` |
| #145 | Job Info subsections are independently collapsible | `658674e` |
| #49  | VB365 Job Statistics / Processing / Sessions tables expand correctly | `b9074e1` |

## Features / enhancements

- **Cloud Connect** (originally PR #161): gateway RAM rendered as GB (bytes→GB), tenant headers renamed (`Throttle Value`→`Max Bandwidth`, `Throttle Unit`→`Bandwidth Unit`), `MaxConcurrentTask=0`→"Unlimited", and a new performance sub-table — `78b9e0f`, `4d1a342`

## Release / CI tooling (internal)

- Manual-release prerelease input flag — `2ed04e2`
- Structured release-notes changelog generation — `2b9631d`
- VirusTotal upload fixes: use `curl.exe`, large-file (>32 MB) upload URL, correct `VIRUSTOTAL_API_KEY` secret name, stdout error logging + git-log changelog fallback — `9be228e`, `fa15f77`, `b5655e0`, `d978dc0`
- CI hardening: move run-step interpolations to env vars (semgrep shell-injection), remove invalid `secrets` context from `workflow_dispatch` conditions — `1403524`, `c5e442c`

## Validation

`#125` and the physical-renderer fix were validated end-to-end against a live Veeam B&R v13 lab (build 13.0.2.29): fresh collection (all 21 collectors succeeded, 42 CSVs, no errors) → generated HTML report cross-checked against live VBR API data. Every section matched — VMware protected **43**, physical protected **3**, license 500/52, 14 managed servers, 4 repos, 3 SOBRs, 17 jobs. All 7 GitHub Actions workflows pass on `fe1849b`.

---

Fixes #125, fixes #49, fixes #145, fixes #146, fixes #158
