### PR TITLE
fix(e2e): ASCII-only Invoke-VhcE2E.ps1 (fix dev CI)

### DIFF
--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Validation/E2E/Invoke-VhcE2E.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Validation/E2E/Invoke-VhcE2E.ps1
@@ -172,7 +172,7 @@ if ($Mode -in 'live', 'both') {
     #              -> @('/run','/remote','/host=<fqdn>','/scrub:false')
     #              The normal /run /remote path uses the DPAPI-stored cred for the
     #              host (seed once: VeeamHealthCheck.exe /savecreds /host=<fqdn>),
-    #              or a /credfile= when supplied. NOTE: do NOT add /silent here —
+    #              or a /credfile= when supplied. NOTE: do NOT add /silent here --
     #              its credential lookup misses stored creds that the normal path
     #              resolves, which breaks unattended remote collection.
     $liveArgs =


### PR DESCRIPTION
## Summary

Hotfix for the `dev` CI failure after #164 merged.

## Root cause

`Invoke-VhcE2E.ps1` (added in #164) contained a U+2014 em-dash in a comment. The Windows `build-and-test` job runs `PowerShell51CompatibilityTests.AllVbrScripts_ShouldContainOnlyAsciiCharacters`, which fails the build on any non-ASCII character in a VBR script. The cross-platform PR checks don't run that Windows-only xUnit guard, so it passed PR review and only failed post-merge on `dev`.

Failed run: https://github.com/VeeamHub/veeam-healthcheck/actions/runs/27220547314

## Fix

Replaced the em-dash with `--` (1 char). Verified locally:
- 0 non-ASCII bytes remain in the file.
- `dotnet test --filter PowerShell51CompatibilityTests` -> **89/89 passed**.