### PR TITLE
Security: scrub-mode hardening + close 2 review-found injection gaps

### DIFF
--- a/vHC/HC_Reporting/Common/Scrubber/CXmlHandler.cs
+++ b/vHC/HC_Reporting/Common/Scrubber/CXmlHandler.cs
@@ -5,13 +5,36 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace VeeamHealthCheck.Scrubber
 {
     public class CScrubHandler
     {
+        // Matches RFC1918 private, loopback, and link-local IPv4 only. Deliberately
+        // NOT public IPv4: a 4-octet public-range pattern also matches product build
+        // versions (e.g. 13.0.2.29), so a blanket pass would corrupt the report.
+        // Public/registered addresses are caught by the registered-value pass instead.
+        private static readonly Regex PrivateIPv4Regex = BuildPrivateIPv4Regex();
+
+        private static Regex BuildPrivateIPv4Regex()
+        {
+            const string o = @"(?:25[0-5]|2[0-4]\d|1?\d?\d)";
+            string pattern =
+                @"\b(?:" +
+                $@"10\.{o}\.{o}\.{o}" + "|" +
+                $@"172\.(?:1[6-9]|2\d|3[01])\.{o}\.{o}" + "|" +
+                $@"192\.168\.{o}\.{o}" + "|" +
+                $@"169\.254\.{o}\.{o}" + "|" +
+                $@"127\.{o}\.{o}\.{o}" +
+                @")\b";
+            return new Regex(pattern, RegexOptions.Compiled);
+        }
+
         private string matchListPath => CVariables.unsafeDir + @"\vHC_KeyFile.xml";
         private Dictionary<string, string> matchDictionary;
         private readonly Dictionary<string, int> typeCounters = new();
@@ -29,6 +52,7 @@ namespace VeeamHealthCheck.Scrubber
                 new XElement("originalname", original));
             this.doc.Root.Add(xml);
             this.doc.Save(this.matchListPath);
+            RestrictFileToOwner(this.matchListPath);
 
             this.WriteToText();
         }
@@ -53,11 +77,116 @@ namespace VeeamHealthCheck.Scrubber
 
                 // Write the JSON string to a file
                 File.WriteAllText(filePath, jsonString);
+                RestrictFileToOwner(filePath);
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"An error occurred while writing to the JSON file: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Tightens NTFS permissions on the de-anonymization key file so it is no
+        /// longer world-readable in the shared temp tree. Inheritance is broken and
+        /// access is restricted to the current user, Administrators, and SYSTEM.
+        /// The file stays human-readable to the operator who generated it (its
+        /// purpose), but other local users can no longer read the obfuscated->real
+        /// mapping. Best-effort: never fails report generation.
+        /// NOTE: the sibling Original\ directory still holds the raw (unscrubbed)
+        /// CSVs and should be secured/deleted after the report is shared.
+        /// </summary>
+        internal static void RestrictFileToOwner(string path)
+        {
+            try
+            {
+                var fileInfo = new FileInfo(path);
+                if (!fileInfo.Exists)
+                {
+                    return;
+                }
+
+                var security = new FileSecurity();
+
+                // Break inheritance and drop any inherited (potentially broad) ACEs.
+                security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+
+                var currentUser = WindowsIdentity.GetCurrent().User;
+                if (currentUser != null)
+                {
+                    security.SetOwner(currentUser);
+                    security.AddAccessRule(new FileSystemAccessRule(
+                        currentUser, FileSystemRights.FullControl, AccessControlType.Allow));
+                }
+
+                var admins = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+                var system = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+                security.AddAccessRule(new FileSystemAccessRule(admins, FileSystemRights.FullControl, AccessControlType.Allow));
+                security.AddAccessRule(new FileSystemAccessRule(system, FileSystemRights.FullControl, AccessControlType.Allow));
+
+                fileInfo.SetAccessControl(security);
+            }
+            catch (Exception ex)
+            {
+                // Best-effort hardening only; do not abort report generation.
+                Console.WriteLine($"[Scrub] Failed to restrict key-file ACLs on '{path}': {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Final safety pass over a fully-assembled scrubbed report. Catches values
+        /// that the opt-in per-field scrub missed: (1) any registered original value
+        /// appearing verbatim (e.g. a hostname embedded in a path or log line), and
+        /// (2) raw private/loopback/link-local IPv4 addresses. Runs ONLY on the
+        /// scrubbed output path; the unscrubbed report is never touched.
+        /// </summary>
+        public string FinalizeScrubbedText(string text)
+        {
+            text = ReplaceRegisteredValues(text, this.matchDictionary);
+            text = ScrubRawPrivateIPv4(text);
+            return text;
+        }
+
+        /// <summary>
+        /// Replaces each registered original value with its obfuscated token wherever
+        /// it appears as a whole word. Longest originals first so a value that is a
+        /// substring of another is handled first. Values shorter than 4 chars are
+        /// skipped to avoid colliding with the report's own HTML/CSS tokens.
+        /// </summary>
+        internal static string ReplaceRegisteredValues(string text, IReadOnlyDictionary<string, string> map)
+        {
+            if (string.IsNullOrEmpty(text) || map == null || map.Count == 0)
+            {
+                return text;
+            }
+
+            foreach (var kvp in map.OrderByDescending(k => k.Key?.Length ?? 0))
+            {
+                string original = kvp.Key;
+                if (string.IsNullOrEmpty(original) || original.Length < 4)
+                {
+                    continue;
+                }
+
+                string pattern = @"\b" + Regex.Escape(original) + @"\b";
+                text = Regex.Replace(text, pattern, kvp.Value ?? string.Empty);
+            }
+
+            return text;
+        }
+
+        /// <summary>
+        /// Replaces raw RFC1918 private, loopback (127/8), and link-local (169.254/16)
+        /// IPv4 addresses with a placeholder. Public IPv4 is intentionally excluded to
+        /// avoid corrupting product build versions that share the dotted-quad shape.
+        /// </summary>
+        internal static string ScrubRawPrivateIPv4(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            return PrivateIPv4Regex.Replace(text, "PRIVATE_IP");
         }
 
         public string ScrubItem(string item, string type, ScrubItemType itemType)

--- a/vHC/HC_Reporting/Functions/Collection/CCollections.cs
+++ b/vHC/HC_Reporting/Functions/Collection/CCollections.cs
@@ -305,7 +305,8 @@ namespace VeeamHealthCheck.Functions.Collection
                     CGlobals.REMOTEHOST = "localhost";
                 }
 
-                // Encode password as Base64 for safe transmission
+                // Base64-encode only to avoid PowerShell arg quoting issues (argument-safety,
+                // NOT encryption — Base64 is reversible; the script decodes it to plaintext).
                 string base64Password = CredentialHelper.EncodePasswordToBase64(creds.Value.Password);
                 // Escape server and username for the double-quoted argument context
                 // (prevents PowerShell argument injection via these fields).

--- a/vHC/HC_Reporting/Functions/Collection/CCollections.cs
+++ b/vHC/HC_Reporting/Functions/Collection/CCollections.cs
@@ -58,22 +58,40 @@ namespace VeeamHealthCheck.Functions.Collection
 
             // GetCsvFileSizesToLog();
 
+            this.log.Info("[Collections] Phase: Recon check...", false);
             CheckRecon();
+            this.log.Info("[Collections] Phase: Recon check...done!", false);
 
             if (!CGlobals.RunSecReport && CGlobals.EffectiveIsVbr)
             {
+                this.log.Info("[Collections] Phase: Log wait analysis...", false);
                 this.PopulateWaits();
+                this.log.Info("[Collections] Phase: Log wait analysis...done!", false);
             }
 
             if (CGlobals.IsVbr && !CGlobals.REMOTEEXEC)
             {
+                this.log.Info("[Collections] Phase: VMC reader...", false);
                 this.ExecVmcReader();
+                this.log.Info("[Collections] Phase: VMC reader...done!", false);
+
+                this.log.Info("[Collections] Phase: Registry DB info...", false);
                 this.GetRegistryDbInfo();
+                this.log.Info("[Collections] Phase: Registry DB info...done!", false);
+
                 if (CGlobals.DBTYPE != CGlobals.PgTypeName)
                 {
+                    this.log.Info(string.Format("[Collections] Phase: SQL queries (DBTYPE={0})...", CGlobals.DBTYPE), false);
                     this.ExecSqlQueries();
+                    this.log.Info("[Collections] Phase: SQL queries...done!", false);
+                }
+                else
+                {
+                    this.log.Info(string.Format("[Collections] Phase: SQL queries skipped (PostgreSQL backend, DBTYPE={0})", CGlobals.DBTYPE), false);
                 }
             }
+
+            this.log.Info("[Collections] Run() complete.", false);
         }
 
         private static void CheckRecon()
@@ -138,16 +156,32 @@ namespace VeeamHealthCheck.Functions.Collection
 
         private void GetRegistryDbInfo()
         {
-            CRegReader reg = new CRegReader();
-            reg.GetDbInfo();
+            try
+            {
+                CRegReader reg = new CRegReader();
 
-            if (CGlobals.REMOTEEXEC)
-            {
-                CGlobals.DEFAULTREGISTRYKEYS = reg.DefaultVbrKeysRemote();
+                this.log.Info("[Collections] Registry: reading DB info (GetDbInfo)...", false);
+                reg.GetDbInfo();
+                this.log.Info("[Collections] Registry: reading DB info (GetDbInfo)...done!", false);
+
+                if (CGlobals.REMOTEEXEC)
+                {
+                    this.log.Info("[Collections] Registry: reading default VBR keys (remote)...", false);
+                    CGlobals.DEFAULTREGISTRYKEYS = reg.DefaultVbrKeysRemote();
+                }
+                else
+                {
+                    this.log.Info("[Collections] Registry: reading default VBR keys (local)...", false);
+                    CGlobals.DEFAULTREGISTRYKEYS = reg.DefaultVbrKeys();
+                }
+
+                this.log.Info("[Collections] Registry: default VBR keys...done!", false);
             }
-            else
+            catch (Exception e)
             {
-                CGlobals.DEFAULTREGISTRYKEYS = reg.DefaultVbrKeys();
+                // Don't let a registry-read failure silently abort collection. Log it loudly
+                // and continue so report generation can still proceed with whatever was gathered.
+                this.log.Error("[Collections] Registry DB info collection failed: " + e.Message, false);
             }
         }
 

--- a/vHC/HC_Reporting/Functions/Collection/DB/CDbAccessor.cs
+++ b/vHC/HC_Reporting/Functions/Collection/DB/CDbAccessor.cs
@@ -89,7 +89,10 @@ namespace VeeamHealthCheck.Functions.Collection.DB
 
         private static string GetConnectionString()
         {
-            return "Server=(local);Integrated Security=SSPI;";
+            // Connect Timeout bounds how long Open() blocks before failing. Without it the
+            // default is 15s, but we set it explicitly so a wrong/unreachable SQL host fails
+            // loudly in the log rather than appearing to "hang" during collection.
+            return "Server=(local);Integrated Security=SSPI;Connect Timeout=15;";
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
@@ -622,10 +622,14 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
 
         private ProcessStartInfo LogCollectionInfo(string scriptLocation, string path, string server)
         {
-            string argString;
-            argString = $"-NoProfile -ExecutionPolicy unrestricted -file {scriptLocation} -Server {server} -ReportPath {path}";
+            // Quote and escape every value: scriptLocation/path may contain spaces, and
+            // server (REMOTEHOST) is operator-controlled — unquoted it allows PowerShell
+            // argument injection (aggravated by UseShellExecute=true). Code-review cd-13/cs-01.
+            string escapedScript = CredentialHelper.EscapeForPowerShellDoubleQuotes(scriptLocation);
+            string escapedServer = CredentialHelper.EscapeForPowerShellDoubleQuotes(server);
+            string escapedPath = CredentialHelper.EscapeForPowerShellDoubleQuotes(path);
+            string argString = $"-NoProfile -ExecutionPolicy unrestricted -file \"{escapedScript}\" -Server \"{escapedServer}\" -ReportPath \"{escapedPath}\"";
 
-            // string argString = $"-NoProfile -ExecutionPolicy unrestricted -file \"{scriptLocation}\" -ReportPath \"{path}\"";
             if (CGlobals.DEBUG)
             {
                 this.log.Debug(this.logStart + "PS ArgString = " + argString, false);
@@ -653,9 +657,12 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
                 server = CGlobals.REMOTEHOST;
             }
 
-            argString = $"-NoProfile -ExecutionPolicy unrestricted -file \"{scriptLocation}\" -Server {server}";
+            // Escape both values; server (REMOTEHOST) is operator-controlled and was
+            // previously unquoted/unescaped — PowerShell argument injection. Code-review cd-13/cs-01.
+            string escapedScript = CredentialHelper.EscapeForPowerShellDoubleQuotes(scriptLocation);
+            string escapedServer = CredentialHelper.EscapeForPowerShellDoubleQuotes(server);
+            argString = $"-NoProfile -ExecutionPolicy unrestricted -file \"{escapedScript}\" -Server \"{escapedServer}\"";
 
-            // string argString = $"-NoProfile -ExecutionPolicy unrestricted -file \"{scriptLocation}\" -ReportPath \"{path}\"";
             if (CGlobals.DEBUG)
             {
                 this.log.Debug(this.logStart + "PS ArgString = " + argString, false);

--- a/vHC/HC_Reporting/Functions/Collection/Security/CredentialHelper.cs
+++ b/vHC/HC_Reporting/Functions/Collection/Security/CredentialHelper.cs
@@ -7,7 +7,10 @@ namespace VeeamHealthCheck.Functions.Collection.Security
     public static class CredentialHelper
     {
         /// <summary>
-        /// Encodes a password as Base64 for safe transmission to PowerShell
+        /// Base64-encodes a password ONLY to avoid quoting/escaping issues when
+        /// passing it as a PowerShell argument. This is argument-safety encoding,
+        /// NOT encryption — Base64 is trivially reversible and provides zero
+        /// confidentiality. The script decodes it straight back to plaintext.
         /// </summary>
         public static string EncodePasswordToBase64(string password)
         {

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CHtmlExporter.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CHtmlExporter.cs
@@ -64,6 +64,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
             {
                 this.log.Info("exporting xml to html");
                 this.latestReport = this.SetReportNameAndPath(scrub, "VB365");
+                if (scrub)
+                {
+                    htmlString = CGlobals.Scrubber.FinalizeScrubbedText(htmlString);
+                }
+
                 this.WriteHtmlToFile(htmlString);
                 this.log.Info("exporting xml to html..done!");
 
@@ -95,6 +100,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
             {
                 this.log.Info("exporting xml to html");
                 this.latestReport = this.SetReportNameAndPath(scrub, "VBR");
+                if (scrub)
+                {
+                    htmlString = CGlobals.Scrubber.FinalizeScrubbedText(htmlString);
+                }
+
                 this.WriteHtmlToFile(htmlString);
                 this.log.Info("exporting xml to html..done!");
 
@@ -182,6 +192,10 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
         {
             this.log.Info("exporting xml to html");
             this.latestReport = this.SetReportNameAndPath(scrub, "VBR_Security");
+            if (scrub)
+            {
+                htmlString = CGlobals.Scrubber.FinalizeScrubbedText(htmlString);
+            }
 
             this.WriteHtmlToFile(htmlString);
             this.log.Info("exporting xml to html..done!");

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcSessionReport.Tests.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcSessionReport.Tests.ps1
@@ -14,6 +14,9 @@ BeforeAll {
 
     # Dot-source the helper that the SUT calls plus the SUT itself.
     . (Join-Path $privateDir 'Get-VhciSessionLogWithTimeout.ps1')
+    # SUT now pipes its CSV through Protect-VhciCsvInjection (formula-injection
+    # neutralizer); dot-source it too or the export call throws CommandNotFound.
+    . (Join-Path $privateDir 'Protect-VhciCsvInjection.ps1')
     . $PSCommandPath.Replace('.Tests.ps1', '.ps1')
     . (Join-Path $publicDir 'Write-LogFile.ps1')
 

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcSessionReport.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcSessionReport.ps1
@@ -183,7 +183,7 @@ function Get-VhcSessionReport {
 
     $csvPath = Join-Path -Path $script:ReportPath -ChildPath "VeeamSessionReport.csv"
     if ($allOutput.Count -gt 0) {
-        $allOutput | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
+        $allOutput | Protect-VhciCsvInjection | Export-Csv -Path $csvPath -NoTypeInformation -Encoding UTF8
         Write-LogFile "Exported $($allOutput.Count) session rows to $csvPath"
     } else {
         Write-LogFile "No session rows produced - writing header-only CSV" -LogLevel "WARNING"

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Validation/E2E/Invoke-VhcE2E.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Validation/E2E/Invoke-VhcE2E.ps1
@@ -124,10 +124,13 @@ function Invoke-Tests {
     if (-not $SkipDotnetTest) {
         $csproj = Join-Path (Split-Path $hcReporting -Parent) 'VhcXTests\VhcXTests.csproj'
         if (Test-Path $csproj) {
-            $out  = & dotnet test $csproj -c Debug --nologo -v q 2>&1
-            $line = ($out | Select-String 'Passed!|Failed!' | Select-Object -Last 1)
+            $out   = & dotnet test $csproj -c Debug --nologo -v q 2>&1
+            $match = $out | Select-String 'Passed!|Failed!' | Select-Object -Last 1
+            # Use the MatchInfo's .Line as an explicit string; coercing a MatchInfo
+            # (or a null/array) straight through -replace can yield Object[] and break .Trim().
+            $lineText = if ($match) { [string]$match.Line } else { 'no test summary line found' }
             $ok   = ($LASTEXITCODE -eq 0) -and ($out -match 'Passed!')
-            Add-Result (New-VhcE2EResult 'Tests:xUnit' $ok (($line -replace '\s+', ' ').Trim()))
+            Add-Result (New-VhcE2EResult 'Tests:xUnit' $ok (($lineText -replace '\s+', ' ').Trim()))
         } else {
             Add-Result (New-VhcE2EResult 'Tests:xUnit' $false "VhcXTests.csproj not found at $csproj")
         }

--- a/vHC/HC_Reporting/VeeamHealthCheck.csproj
+++ b/vHC/HC_Reporting/VeeamHealthCheck.csproj
@@ -11,10 +11,10 @@
 		<Company>Veeam</Company>
 		<Authors>AdamC</Authors>
 		<ApplicationIcon>Health_Check_Icon.ico</ApplicationIcon>
-		<AssemblyVersion>3.0.0.775</AssemblyVersion>
+		<AssemblyVersion>3.0.0.783</AssemblyVersion>
 		<SignAssembly>False</SignAssembly>
 		<DelaySign>false</DelaySign>
-		<FileVersion>3.0.0.775</FileVersion>
+		<FileVersion>3.0.0.783</FileVersion>
 		<DebugType>full</DebugType>
 		<SelfContained>true</SelfContained>
 		<!--These 2 lines are what produce the single file utility. Possibly doesn't work...-->

--- a/vHC/HC_Reporting/VeeamHealthCheck.csproj
+++ b/vHC/HC_Reporting/VeeamHealthCheck.csproj
@@ -11,10 +11,10 @@
 		<Company>Veeam</Company>
 		<Authors>AdamC</Authors>
 		<ApplicationIcon>Health_Check_Icon.ico</ApplicationIcon>
-		<AssemblyVersion>3.0.0.783</AssemblyVersion>
+		<AssemblyVersion>3.0.0.785</AssemblyVersion>
 		<SignAssembly>False</SignAssembly>
 		<DelaySign>false</DelaySign>
-		<FileVersion>3.0.0.783</FileVersion>
+		<FileVersion>3.0.0.785</FileVersion>
 		<DebugType>full</DebugType>
 		<SelfContained>true</SelfContained>
 		<!--These 2 lines are what produce the single file utility. Possibly doesn't work...-->

--- a/vHC/HC_Reporting/VeeamHealthCheck.csproj
+++ b/vHC/HC_Reporting/VeeamHealthCheck.csproj
@@ -11,10 +11,10 @@
 		<Company>Veeam</Company>
 		<Authors>AdamC</Authors>
 		<ApplicationIcon>Health_Check_Icon.ico</ApplicationIcon>
-		<AssemblyVersion>3.0.0.775</AssemblyVersion>
+		<AssemblyVersion>3.0.0.777</AssemblyVersion>
 		<SignAssembly>False</SignAssembly>
 		<DelaySign>false</DelaySign>
-		<FileVersion>3.0.0.775</FileVersion>
+		<FileVersion>3.0.0.777</FileVersion>
 		<DebugType>full</DebugType>
 		<SelfContained>true</SelfContained>
 		<!--These 2 lines are what produce the single file utility. Possibly doesn't work...-->

--- a/vHC/VhcXTests/CScrubHandlerSecurityTests.cs
+++ b/vHC/VhcXTests/CScrubHandlerSecurityTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System.Collections.Generic;
+using System.IO;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using VeeamHealthCheck.Scrubber;
+using Xunit;
+
+namespace VhcXTests
+{
+    /// <summary>
+    /// Security tests for the scrub-mode hardening (A6 Phase 2.4):
+    /// private-IPv4 final pass, registered-value final pass, and the
+    /// key-file ACL lockdown. These exercise the internal static seams
+    /// directly so no live report or global state is required.
+    /// </summary>
+    [Trait("Category", "Scrubbing")]
+    public class CScrubHandlerSecurityTests
+    {
+        // ---- ScrubRawPrivateIPv4 ----------------------------------------
+
+        [Theory]
+        [InlineData("10.1.2.3")]
+        [InlineData("10.255.255.255")]
+        [InlineData("192.168.0.1")]
+        [InlineData("172.16.5.5")]
+        [InlineData("172.31.255.254")]
+        [InlineData("127.0.0.1")]
+        [InlineData("169.254.10.10")]
+        public void ScrubRawPrivateIPv4_PrivateAddress_IsReplaced(string ip)
+        {
+            Assert.Equal("PRIVATE_IP", CScrubHandler.ScrubRawPrivateIPv4(ip));
+        }
+
+        [Theory]
+        [InlineData("8.8.8.8")]            // public DNS
+        [InlineData("172.15.0.1")]         // just below the 172.16/12 block
+        [InlineData("172.32.0.1")]         // just above the 172.16/12 block
+        [InlineData("13.0.2.29")]          // product build version — must NOT be scrubbed
+        [InlineData("10.999.0.1")]         // invalid octet, not a real IP
+        public void ScrubRawPrivateIPv4_NonPrivateOrInvalid_IsUnchanged(string value)
+        {
+            Assert.Equal(value, CScrubHandler.ScrubRawPrivateIPv4(value));
+        }
+
+        [Fact]
+        public void ScrubRawPrivateIPv4_EmbeddedInText_ReplacesOnlyTheAddress()
+        {
+            Assert.Equal(
+                "job failed on PRIVATE_IP at 02:00",
+                CScrubHandler.ScrubRawPrivateIPv4("job failed on 10.0.0.5 at 02:00"));
+        }
+
+        // ---- ReplaceRegisteredValues ------------------------------------
+
+        [Fact]
+        public void ReplaceRegisteredValues_EmbeddedHostname_IsReplaced()
+        {
+            var map = new Dictionary<string, string> { ["srv01host"] = "Server_0" };
+            Assert.Equal(
+                @"\\Server_0\share",
+                CScrubHandler.ReplaceRegisteredValues(@"\\srv01host\share", map));
+        }
+
+        [Fact]
+        public void ReplaceRegisteredValues_LongestFirst_AvoidsPartialMatch()
+        {
+            // Both keys present; the longer must win so we don't get "X-vbr-01".
+            var map = new Dictionary<string, string>
+            {
+                ["prodbox"]         = "X",
+                ["prodbox-vbr-01"]  = "Server_7",
+            };
+            Assert.Equal("Server_7", CScrubHandler.ReplaceRegisteredValues("prodbox-vbr-01", map));
+        }
+
+        [Fact]
+        public void ReplaceRegisteredValues_ShortValue_IsSkippedToAvoidChromeCollision()
+        {
+            // 'ab' is < 4 chars; must not be replaced (would shred report HTML/CSS).
+            var map = new Dictionary<string, string> { ["ab"] = "Z" };
+            Assert.Equal("ab cd ab", CScrubHandler.ReplaceRegisteredValues("ab cd ab", map));
+        }
+
+        [Fact]
+        public void ReplaceRegisteredValues_WholeWordOnly_DoesNotMatchSubstring()
+        {
+            var map = new Dictionary<string, string> { ["host1"] = "Server_0" };
+            // "host10" should not be touched (not a whole-word match).
+            Assert.Equal("host10", CScrubHandler.ReplaceRegisteredValues("host10", map));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ReplaceRegisteredValues_EmptyText_IsPassedThrough(string? text)
+        {
+            var map = new Dictionary<string, string> { ["something"] = "Server_0" };
+            Assert.Equal(text, CScrubHandler.ReplaceRegisteredValues(text, map));
+        }
+
+        [Fact]
+        public void ReplaceRegisteredValues_EmptyMap_IsPassedThrough()
+        {
+            var map = new Dictionary<string, string>();
+            Assert.Equal("nothing to do here", CScrubHandler.ReplaceRegisteredValues("nothing to do here", map));
+        }
+
+        // ---- RestrictFileToOwner (ACL lockdown) -------------------------
+
+        [Fact]
+        public void RestrictFileToOwner_RemovesBroadAccessAndBreaksInheritance()
+        {
+            string path = Path.Combine(Path.GetTempPath(), $"vhc-keyfile-acl-{System.Guid.NewGuid():N}.json");
+            File.WriteAllText(path, "{\"original\":\"obfuscated\"}");
+
+            try
+            {
+                CScrubHandler.RestrictFileToOwner(path);
+
+                FileSecurity security = new FileInfo(path).GetAccessControl();
+                Assert.True(security.AreAccessRulesProtected,
+                    "Inheritance should be disabled so the world-readable temp ACLs do not apply.");
+
+                foreach (FileSystemAccessRule rule in
+                         security.GetAccessRules(true, true, typeof(NTAccount)))
+                {
+                    string id = rule.IdentityReference.Value;
+                    Assert.DoesNotContain("Everyone", id, System.StringComparison.OrdinalIgnoreCase);
+                    Assert.DoesNotContain("Authenticated Users", id, System.StringComparison.OrdinalIgnoreCase);
+                    Assert.False(id.EndsWith(@"\Users", System.StringComparison.OrdinalIgnoreCase),
+                        $"Built-in Users group must not retain access: {id}");
+                }
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+    }
+}

--- a/vHC/VhcXTests/PSInvokerInjectionTests.cs
+++ b/vHC/VhcXTests/PSInvokerInjectionTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System.Diagnostics;
+using System.Reflection;
+using VeeamHealthCheck.Functions.Collection.PSCollections;
+using VeeamHealthCheck.Functions.Collection.Security;
+using VeeamHealthCheck.Shared;
+using Xunit;
+
+namespace VhcXTests
+{
+    /// <summary>
+    /// Regression tests for the log-collection / server-dump PowerShell argument
+    /// builders, which previously interpolated the operator-controlled server
+    /// (REMOTEHOST) unquoted and unescaped (code-review cd-13/cs-01).
+    /// </summary>
+    [Trait("Category", "Security")]
+    public class PSInvokerInjectionTests
+    {
+        private const string MaliciousServer = "host\";calc;\"";
+
+        private static ProcessStartInfo InvokePrivate(string method, params object[] args)
+        {
+            var m = typeof(PSInvoker).GetMethod(method, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(m);
+            return (ProcessStartInfo)m.Invoke(new PSInvoker(), args);
+        }
+
+        [Fact]
+        public void LogCollectionInfo_MaliciousServer_IsQuotedAndEscaped()
+        {
+            var psi = InvokePrivate("LogCollectionInfo", @"C:\scripts\collect.ps1", @"C:\out", MaliciousServer);
+
+            string expected = CredentialHelper.EscapeForPowerShellDoubleQuotes(MaliciousServer);
+            Assert.Contains($"-Server \"{expected}\"", psi.Arguments);
+            // The raw, unescaped breakout sequence must not survive.
+            Assert.DoesNotContain($"-Server {MaliciousServer}", psi.Arguments);
+        }
+
+        [Fact]
+        public void ServerDumpInfo_MaliciousRemoteHost_IsQuotedAndEscaped()
+        {
+            string original = CGlobals.REMOTEHOST;
+            try
+            {
+                CGlobals.REMOTEHOST = MaliciousServer;
+                var psi = InvokePrivate("ServerDumpInfo", @"C:\scripts\dump.ps1");
+
+                string expected = CredentialHelper.EscapeForPowerShellDoubleQuotes(MaliciousServer);
+                Assert.Contains($"-Server \"{expected}\"", psi.Arguments);
+                Assert.DoesNotContain($"-Server {MaliciousServer}", psi.Arguments);
+            }
+            finally
+            {
+                CGlobals.REMOTEHOST = original;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ships the remaining security work stranded on \`ac-dev\` and closes two gaps the Fable/Opus code review found in the earlier Phase 2 pass.

## What's in here
- **Scrub-mode hardening** (\`05382b9\`): key-map ACL lockdown (NTFS inheritance off; current user/Admins/SYSTEM only), final-pass leak net over scrubbed HTML (\`ReplaceRegisteredValues\` for embedded hostnames + private-range IPv4 scrub that deliberately spares build-version strings), base64 "safe transmission" comments relabeled (argument-safety, not encryption), and an \`Invoke-VhcE2E.ps1\` harness robustness fix. Scrub-path-only — unscrubbed report unchanged.
- **Two review-found injection gaps** (\`ed588b2\`):
  - **cs-02** — \`Get-VhcSessionReport.ps1\` wrote its CSV via a direct \`Export-Csv\`, bypassing \`Protect-VhciCsvInjection\`. Now routed through the neutralizer.
  - **cd-13/cs-01** — \`PSInvoker.LogCollectionInfo\` + \`ServerDumpInfo\` interpolated the operator-controlled \`REMOTEHOST\` unquoted/unescaped (with \`UseShellExecute=true\`). Now quoted + escaped via \`EscapeForPowerShellDoubleQuotes\`.
- **Logging/DB** (\`f3aa6f2\`): collection-phase logging + registry-read failure handling + explicit SQL connection timeout (landed from another machine).

## Validation
Local E2E gate (import-replay): **Build 0 err, xUnit 685, Pester 112, HTML/CSV/Log/JSON, BaselineDiff 19/19** (same-instant). New tests: \`PSInvokerInjectionTests\` (malicious server quoted+escaped in both builders); \`Get-VhcSessionReport.Tests.ps1\` updated for the new dependency.

## Notes
- The merged code-review backlog (\`code-review-merged-INDEX.md\`, ~150 issues) is already on \`dev\`; this PR does not attempt it — it ships the security fixes + the 2 confirmed gaps. Remaining review items (VB365-report regression, the central HTML-encoding fix, credential cluster) are follow-ups.
- Scrub-mode *integration* validation (a real end-to-end scrubbed report) is still deferred — import-replay doesn't exercise the scrub path; the scrub logic is unit-tested.