### PR TITLE
feat(json): add missing sections to JSON output

### DIFF
--- a/vHC/HC_Reporting/Functions/Reporting/Html/Shared/CSectionTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/Shared/CSectionTable.cs
@@ -241,6 +241,38 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.Shared
         }
 
         /// <summary>
+        /// Returns the list of column header strings for JSON capture.
+        /// </summary>
+        public List<string> JsonHeaders => _columns.Select(c => c.Header).ToList();
+
+        /// <summary>
+        /// Applies each column's extractor to every item and returns raw (non-HTML-encoded)
+        /// string rows for use with <see cref="CHtmlTables.SetSectionPublic"/>.
+        /// Extractor exceptions per cell are caught and replaced with an empty string,
+        /// mirroring the behaviour in <see cref="Render"/>.
+        /// </summary>
+        public List<List<string>> BuildJsonRows(IEnumerable<T> data)
+        {
+            var rows = new List<List<string>>();
+            if (data == null) return rows;
+
+            foreach (var item in data)
+            {
+                var row = new List<string>(_columns.Count);
+                foreach (var col in _columns)
+                {
+                    string value;
+                    try { value = col.Extractor(item) ?? ""; }
+                    catch { value = ""; }
+                    row.Add(value);
+                }
+                rows.Add(row);
+            }
+
+            return rows;
+        }
+
+        /// <summary>
         /// Gets the number of columns defined.
         /// </summary>
         public int ColumnCount => _columns.Count;

--- a/vHC/HC_Reporting/Functions/Reporting/Html/Shared/CSectionTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/Shared/CSectionTable.cs
@@ -240,9 +240,6 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.Shared
             return sb.ToString();
         }
 
-        /// <summary>
-        /// Returns the list of column header strings for JSON capture.
-        /// </summary>
         public List<string> JsonHeaders => _columns.Select(c => c.Header).ToList();
 
         /// <summary>

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CCredentialsTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CCredentialsTable.cs
@@ -39,9 +39,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
                     })
                     .Column("Last Modified", string.Empty, item => (string)(item.lastmodified ?? ""));
 
-                // JSON capture — must happen whether or not there's data so the section key
-                // always appears in the output. Uses the same scrub-aware extractors defined
-                // on the builder above; raw values (no HTML encoding).
+                // Before the empty-data guard — ensures the credentials key is always present in JSON.
                 CHtmlTables.SetSectionPublic("credentials", table.JsonHeaders, table.BuildJsonRows(data), null);
 
                 if (!data.Any())

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CCredentialsTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CCredentialsTable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using VeeamHealthCheck.Functions.Reporting.CsvHandlers;
 using VeeamHealthCheck.Functions.Reporting.Html.Shared;
+using VeeamHealthCheck.Html.VBR;
 using VeeamHealthCheck.Scrubber;
 using VeeamHealthCheck.Shared;
 
@@ -37,6 +38,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
                         return scrub ? CGlobals.Scrubber.ScrubItem(description, ScrubItemType.Item) : description;
                     })
                     .Column("Last Modified", string.Empty, item => (string)(item.lastmodified ?? ""));
+
+                // JSON capture — must happen whether or not there's data so the section key
+                // always appears in the output. Uses the same scrub-aware extractors defined
+                // on the builder above; raw values (no HTML encoding).
+                CHtmlTables.SetSectionPublic("credentials", table.JsonHeaders, table.BuildJsonRows(data), null);
 
                 if (!data.Any())
                     return table.RenderEmpty("No credentials detected.");

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
@@ -80,7 +80,6 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
 
                         s += "</tr>";
 
-                        // Accumulate raw (already-scrubbed) values for JSON capture.
                         jsonRows.Add(new List<string> { isEnabled, smtpServer, fromAddr, toAddr, notifySuccess, notifyWarning, notifyError });
                     }
                 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using VeeamHealthCheck.Functions.Reporting.CsvHandlers;
 using VeeamHealthCheck.Functions.Reporting.Html.Shared;
+using VeeamHealthCheck.Html.VBR;
 using VeeamHealthCheck.Scrubber;
 using VeeamHealthCheck.Shared;
 
@@ -36,6 +37,9 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
             s += this.form.TableHeaderEnd();
             s += this.form.TableBodyStart();
 
+            // Declared before the try so the section is always emitted (empty rows when no data).
+            var jsonRows = new List<List<string>>();
+
             try
             {
                 CCsvParser c = new();
@@ -61,15 +65,23 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
                             toAddr = CGlobals.Scrubber.ScrubItem(toAddr, ScrubItemType.Item);
                         }
 
-                        s += this.form.TableData((string)(item.isenabled ?? ""), string.Empty);
+                        string isEnabled = (string)(item.isenabled ?? "");
+                        string notifySuccess = (string)(item.notifyonsuccess ?? "");
+                        string notifyWarning = (string)(item.notifyonwarning ?? "");
+                        string notifyError = (string)(item.notifyonerror ?? "");
+
+                        s += this.form.TableData(isEnabled, string.Empty);
                         s += this.form.TableData(smtpServer, string.Empty);
                         s += this.form.TableData(fromAddr, string.Empty);
                         s += this.form.TableData(toAddr, string.Empty);
-                        s += this.form.TableData((string)(item.notifyonsuccess ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.notifyonwarning ?? ""), string.Empty);
-                        s += this.form.TableData((string)(item.notifyonerror ?? ""), string.Empty);
+                        s += this.form.TableData(notifySuccess, string.Empty);
+                        s += this.form.TableData(notifyWarning, string.Empty);
+                        s += this.form.TableData(notifyError, string.Empty);
 
                         s += "</tr>";
+
+                        // Accumulate raw (already-scrubbed) values for JSON capture.
+                        jsonRows.Add(new List<string> { isEnabled, smtpServer, fromAddr, toAddr, notifySuccess, notifyWarning, notifyError });
                     }
                 }
             }
@@ -79,6 +91,12 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
             }
 
             s += this.form.SectionEnd();
+
+            CHtmlTables.SetSectionPublic(
+                "emailNotification",
+                new List<string> { "Is Enabled", "SMTP Server", "From", "To", "Notify On Success", "Notify On Warning", "Notify On Error" },
+                jsonRows,
+                null);
 
             return s;
         }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CUserRolesTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CUserRolesTable.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using VeeamHealthCheck.Functions.Reporting.CsvHandlers;
 using VeeamHealthCheck.Functions.Reporting.Html.Shared;
+using VeeamHealthCheck.Html.VBR;
 using VeeamHealthCheck.Scrubber;
 using VeeamHealthCheck.Shared;
 
@@ -26,6 +27,9 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
 
             s += this.form.TableHeaderEnd();
             s += this.form.TableBodyStart();
+
+            // Declared before the try so the section is always emitted (empty rows when no data).
+            var jsonRows = new List<List<string>>();
 
             try
             {
@@ -64,6 +68,9 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
                         s += this.form.TableData(description, string.Empty);
 
                         s += "</tr>";
+
+                        // Accumulate raw (already-scrubbed) values for JSON capture.
+                        jsonRows.Add(new List<string> { name, role, description });
                     }
                 }
             }
@@ -73,6 +80,8 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
             }
 
             s += this.form.SectionEnd();
+
+            CHtmlTables.SetSectionPublic("userRoles", new List<string> { "Name", "Role", "Description" }, jsonRows, null);
 
             return s;
         }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CUserRolesTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CUserRolesTable.cs
@@ -69,7 +69,6 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
 
                         s += "</tr>";
 
-                        // Accumulate raw (already-scrubbed) values for JSON capture.
                         jsonRows.Add(new List<string> { name, role, description });
                     }
                 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Security/CComplianceTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Security/CComplianceTable.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using VeeamHealthCheck.Functions.Analysis.DataModels;
 using VeeamHealthCheck.Functions.Reporting.CsvHandlers;
 using VeeamHealthCheck.Functions.Reporting.Html.Shared;
+using VeeamHealthCheck.Html.VBR;
 using VeeamHealthCheck.Shared;
 
 namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Security
@@ -160,6 +161,9 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Security
                 t += this.form.TableHeaderEnd();
                 t += this.form.TableBodyStart();
 
+                // Accumulate raw values for JSON capture (no badge markup, no NEW span).
+                var jsonRows = new List<List<string>>();
+
                 foreach (var res in this.csvResults)
                 {
                     string labelCell = res.BestPractice;
@@ -171,9 +175,18 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Security
                     t += this.form.TableDataLeftAligned(labelCell, string.Empty);
                     t += this.form.TableData(ComplianceBadge(res.Status.ToString()), string.Empty);
                     t += this.form.TableRowEnd();
+
+                    jsonRows.Add(new List<string> { res.BestPractice, res.Status.ToString() });
                 }
 
                 t += this.form.SectionEnd();
+
+                // Per-rule rows — additive alongside the existing ComplianceScan metadata object.
+                CHtmlTables.SetSectionPublic(
+                    "complianceTable",
+                    new List<string> { "Best Practice", "Status" },
+                    jsonRows,
+                    null);
             }
             catch (Exception e)
             {

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Security/CComplianceTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Security/CComplianceTable.cs
@@ -146,6 +146,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Security
                 if (this.csvResults == null || !this.csvResults.Any())
                 {
                     CGlobals.Logger.Warning("No compliance data available - CSV file may not have been generated");
+                    CHtmlTables.SetSectionPublic("complianceTable", new List<string> { "Best Practice", "Status" }, new List<List<string>>(), null);
                     return t;
                 }
 
@@ -161,7 +162,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Security
                 t += this.form.TableHeaderEnd();
                 t += this.form.TableBodyStart();
 
-                // Accumulate raw values for JSON capture (no badge markup, no NEW span).
+                // Plain text — no badge markup or NEW span, unlike the HTML cells below.
                 var jsonRows = new List<List<string>>();
 
                 foreach (var res in this.csvResults)

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CCredentialsTableScrubTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CCredentialsTableScrubTests.cs
@@ -1,7 +1,10 @@
 // Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
 // MIT License
+using System.Collections.Generic;
 using System.IO;
+using VeeamHealthCheck.Functions.Reporting.DataTypes;
 using VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings;
+using VeeamHealthCheck.Shared;
 using Xunit;
 
 namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
@@ -20,7 +23,11 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
             "\"Name\",\"UserName\",\"Description\",\"LastModified\"\r\n" +
             "\"CORP\\svc-backup\",\"svc-backup\",\"\",\"2024-01-01\"";
 
-        public CCredentialsTableScrubTests() : base("VhcCredScrubTests_") { }
+        public CCredentialsTableScrubTests() : base("VhcCredScrubTests_")
+        {
+            // Reset global JSON state so tests are isolated.
+            CGlobals.FullReportJson = new CFullReportJson();
+        }
 
         private void WriteCredentialsCsv(string content) =>
             File.WriteAllText(System.IO.Path.Combine(VbrDir, "_Credentials.csv"), content);
@@ -50,6 +57,62 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
             WriteCredentialsCsv(CredentialsCsvEmptyDescription);
             var exception = Record.Exception(() => new CCredentialsTable().Render(scrub: true));
             Assert.Null(exception);
+        }
+
+        // --- JSON section capture ---
+
+        [Fact]
+        public void Render_PopulatesJsonSection_CredentialsKey()
+        {
+            WriteCredentialsCsv(CredentialsCsv);
+            new CCredentialsTable().Render(scrub: false);
+
+            Assert.True(CGlobals.FullReportJson.Sections.ContainsKey("credentials"),
+                "Expected Sections[\"credentials\"] to be populated after Render.");
+        }
+
+        [Fact]
+        public void Render_JsonSection_HasExpectedHeaders()
+        {
+            WriteCredentialsCsv(CredentialsCsv);
+            new CCredentialsTable().Render(scrub: false);
+
+            var section = CGlobals.FullReportJson.Sections["credentials"];
+            Assert.Equal(new List<string> { "Name", "User Name", "Description", "Last Modified" }, section.Headers);
+        }
+
+        [Fact]
+        public void Render_JsonSection_ContainsOneRowForOneCsvRecord()
+        {
+            WriteCredentialsCsv(CredentialsCsv);
+            new CCredentialsTable().Render(scrub: false);
+
+            var section = CGlobals.FullReportJson.Sections["credentials"];
+            Assert.Single(section.Rows);
+            Assert.Equal("CORP\\svc-backup", section.Rows[0][0]); // Name column
+        }
+
+        [Fact]
+        public void Render_ScrubTrue_JsonSection_NameIsScrubbed()
+        {
+            WriteCredentialsCsv(CredentialsCsv);
+            new CCredentialsTable().Render(scrub: true);
+
+            var section = CGlobals.FullReportJson.Sections["credentials"];
+            Assert.Single(section.Rows);
+            Assert.DoesNotContain("CORP\\svc-backup", section.Rows[0][0]);
+        }
+
+        [Fact]
+        public void Render_EmptyData_JsonSection_StillPresentWithZeroRows()
+        {
+            // Write a CSV with headers only — no data rows.
+            File.WriteAllText(System.IO.Path.Combine(VbrDir, "_Credentials.csv"),
+                "\"Name\",\"UserName\",\"Description\",\"LastModified\"\r\n");
+            new CCredentialsTable().Render(scrub: false);
+
+            Assert.True(CGlobals.FullReportJson.Sections.ContainsKey("credentials"));
+            Assert.Empty(CGlobals.FullReportJson.Sections["credentials"].Rows);
         }
     }
 }

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTableTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System.Collections.Generic;
+using System.IO;
+using VeeamHealthCheck.Functions.Reporting.DataTypes;
+using VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings;
+using VeeamHealthCheck.Shared;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
+{
+    [Trait("Category", "Scrubbing")]
+    [Collection("GlobalState")]
+    public class CEmailNotificationTableTests : VbrTableScrubTestBase
+    {
+        // FileFinder matches "_EmailNotification.csv"; CsvHelper lowercases headers via
+        // PrepareHeaderForMatch, so dynamic properties are accessed as "smtpserver", "from", etc.
+        private const string EmailNotificationCsv =
+            "\"IsEnabled\",\"SmtpServer\",\"From\",\"To\",\"NotifyOnSuccess\",\"NotifyOnWarning\",\"NotifyOnError\"\r\n" +
+            "\"True\",\"smtp.corp.example.com\",\"veeam@corp.example.com\",\"admin@corp.example.com\",\"False\",\"True\",\"True\"";
+
+        public CEmailNotificationTableTests() : base("VhcEmailNotifTests_")
+        {
+            CGlobals.FullReportJson = new CFullReportJson();
+        }
+
+        private void WriteEmailCsv(string content) =>
+            File.WriteAllText(System.IO.Path.Combine(VbrDir, "_EmailNotification.csv"), content);
+
+        // --- HTML rendering ---
+
+        [Fact]
+        public void Render_ScrubFalse_ContainsSmtpServer()
+        {
+            WriteEmailCsv(EmailNotificationCsv);
+            string html = new CEmailNotificationTable().Render(scrub: false);
+
+            Assert.Contains("smtp.corp.example.com", html);
+        }
+
+        [Fact]
+        public void Render_ScrubTrue_SmtpServerIsScrubbed()
+        {
+            WriteEmailCsv(EmailNotificationCsv);
+            string html = new CEmailNotificationTable().Render(scrub: true);
+
+            Assert.DoesNotContain("smtp.corp.example.com", html);
+        }
+
+        [Fact]
+        public void Render_ScrubTrue_DoesNotThrow()
+        {
+            WriteEmailCsv(EmailNotificationCsv);
+            var exception = Record.Exception(() => new CEmailNotificationTable().Render(scrub: true));
+            Assert.Null(exception);
+        }
+
+        // --- JSON section capture ---
+
+        [Fact]
+        public void Render_PopulatesJsonSection_EmailNotificationKey()
+        {
+            WriteEmailCsv(EmailNotificationCsv);
+            new CEmailNotificationTable().Render(scrub: false);
+
+            Assert.True(CGlobals.FullReportJson.Sections.ContainsKey("emailNotification"),
+                "Expected Sections[\"emailNotification\"] to be populated after Render.");
+        }
+
+        [Fact]
+        public void Render_JsonSection_HasExpectedHeaders()
+        {
+            WriteEmailCsv(EmailNotificationCsv);
+            new CEmailNotificationTable().Render(scrub: false);
+
+            var section = CGlobals.FullReportJson.Sections["emailNotification"];
+            Assert.Equal(
+                new List<string> { "Is Enabled", "SMTP Server", "From", "To", "Notify On Success", "Notify On Warning", "Notify On Error" },
+                section.Headers);
+        }
+
+        [Fact]
+        public void Render_JsonSection_ContainsOneRowForOneCsvRecord()
+        {
+            WriteEmailCsv(EmailNotificationCsv);
+            new CEmailNotificationTable().Render(scrub: false);
+
+            var section = CGlobals.FullReportJson.Sections["emailNotification"];
+            Assert.Single(section.Rows);
+            Assert.Equal("True", section.Rows[0][0]);                       // Is Enabled
+            Assert.Equal("smtp.corp.example.com", section.Rows[0][1]);      // SMTP Server
+            Assert.Equal("veeam@corp.example.com", section.Rows[0][2]);     // From
+            Assert.Equal("admin@corp.example.com", section.Rows[0][3]);     // To
+        }
+
+        [Fact]
+        public void Render_ScrubTrue_JsonSection_SmtpServerIsScrubbed()
+        {
+            WriteEmailCsv(EmailNotificationCsv);
+            new CEmailNotificationTable().Render(scrub: true);
+
+            var section = CGlobals.FullReportJson.Sections["emailNotification"];
+            Assert.Single(section.Rows);
+            Assert.DoesNotContain("smtp.corp.example.com", section.Rows[0][1]);
+        }
+
+        [Fact]
+        public void Render_EmptyData_JsonSection_StillPresentWithZeroRows()
+        {
+            File.WriteAllText(System.IO.Path.Combine(VbrDir, "_EmailNotification.csv"),
+                "\"IsEnabled\",\"SmtpServer\",\"From\",\"To\",\"NotifyOnSuccess\",\"NotifyOnWarning\",\"NotifyOnError\"\r\n");
+            new CEmailNotificationTable().Render(scrub: false);
+
+            Assert.True(CGlobals.FullReportJson.Sections.ContainsKey("emailNotification"));
+            Assert.Empty(CGlobals.FullReportJson.Sections["emailNotification"].Rows);
+        }
+    }
+}

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CUserRolesTableScrubTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CUserRolesTableScrubTests.cs
@@ -1,7 +1,10 @@
 // Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
 // MIT License
+using System.Collections.Generic;
 using System.IO;
+using VeeamHealthCheck.Functions.Reporting.DataTypes;
 using VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings;
+using VeeamHealthCheck.Shared;
 using Xunit;
 
 namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
@@ -19,7 +22,10 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
             "\"Name\",\"Role\",\"Description\"\r\n" +
             "\"CORP\\jdoe\",\"Veeam Backup Administrator\",\"\"";
 
-        public CUserRolesTableScrubTests() : base("VhcUserRolesScrubTests_") { }
+        public CUserRolesTableScrubTests() : base("VhcUserRolesScrubTests_")
+        {
+            CGlobals.FullReportJson = new CFullReportJson();
+        }
 
         private void WriteUserRolesCsv(string content) =>
             File.WriteAllText(System.IO.Path.Combine(VbrDir, "_UserRoles.csv"), content);
@@ -50,6 +56,74 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
             WriteUserRolesCsv(UserRolesCsvEmptyDescription);
             var exception = Record.Exception(() => new CUserRolesTable().Render(scrub: true));
             Assert.Null(exception);
+        }
+
+        // --- JSON section capture ---
+
+        [Fact]
+        public void Render_PopulatesJsonSection_UserRolesKey()
+        {
+            WriteUserRolesCsv(UserRolesCsv);
+            new CUserRolesTable().Render(scrub: false);
+
+            Assert.True(CGlobals.FullReportJson.Sections.ContainsKey("userRoles"),
+                "Expected Sections[\"userRoles\"] to be populated after Render.");
+        }
+
+        [Fact]
+        public void Render_JsonSection_HasExpectedHeaders()
+        {
+            WriteUserRolesCsv(UserRolesCsv);
+            new CUserRolesTable().Render(scrub: false);
+
+            var section = CGlobals.FullReportJson.Sections["userRoles"];
+            Assert.Equal(new List<string> { "Name", "Role", "Description" }, section.Headers);
+        }
+
+        [Fact]
+        public void Render_JsonSection_ContainsOneRowForOneCsvRecord()
+        {
+            WriteUserRolesCsv(UserRolesCsv);
+            new CUserRolesTable().Render(scrub: false);
+
+            var section = CGlobals.FullReportJson.Sections["userRoles"];
+            Assert.Single(section.Rows);
+            Assert.Equal("CORP\\jdoe", section.Rows[0][0]);                         // Name
+            Assert.Equal("Veeam Backup Administrator", section.Rows[0][1]);         // Role
+            Assert.Contains("John Doe", section.Rows[0][2]);                        // Description
+        }
+
+        [Fact]
+        public void Render_ScrubTrue_JsonSection_NameIsScrubbed()
+        {
+            WriteUserRolesCsv(UserRolesCsv);
+            new CUserRolesTable().Render(scrub: true);
+
+            var section = CGlobals.FullReportJson.Sections["userRoles"];
+            Assert.Single(section.Rows);
+            Assert.DoesNotContain("CORP\\jdoe", section.Rows[0][0]);
+        }
+
+        [Fact]
+        public void Render_ScrubTrue_JsonSection_RoleIsNotScrubbed()
+        {
+            // Role is a Veeam-internal enum string, not PII — should pass through unchanged.
+            WriteUserRolesCsv(UserRolesCsv);
+            new CUserRolesTable().Render(scrub: true);
+
+            var section = CGlobals.FullReportJson.Sections["userRoles"];
+            Assert.Equal("Veeam Backup Administrator", section.Rows[0][1]);
+        }
+
+        [Fact]
+        public void Render_EmptyData_JsonSection_StillPresentWithZeroRows()
+        {
+            File.WriteAllText(System.IO.Path.Combine(VbrDir, "_UserRoles.csv"),
+                "\"Name\",\"Role\",\"Description\"\r\n");
+            new CUserRolesTable().Render(scrub: false);
+
+            Assert.True(CGlobals.FullReportJson.Sections.ContainsKey("userRoles"));
+            Assert.Empty(CGlobals.FullReportJson.Sections["userRoles"].Rows);
         }
     }
 }

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/Security/CComplianceTableJsonTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/Security/CComplianceTableJsonTests.cs
@@ -132,5 +132,17 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.Security
             Assert.NotNull(CGlobals.FullReportJson.ComplianceScan);
             Assert.Equal(2, CGlobals.FullReportJson.ComplianceScan.RuleCount);
         }
+
+        [Fact]
+        public void ComplianceTable_NoData_JsonSection_StillPresentWithZeroRows()
+        {
+            // No CSV written — csvResults will be empty, triggering the early-return path.
+            var ct = new CComplianceTable();
+            ct.ComplianceTable();
+
+            Assert.True(CGlobals.FullReportJson.Sections.ContainsKey("complianceTable"),
+                "Expected Sections[\"complianceTable\"] to be present even when no compliance data is available.");
+            Assert.Empty(CGlobals.FullReportJson.Sections["complianceTable"].Rows);
+        }
     }
 }

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/Security/CComplianceTableJsonTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/Security/CComplianceTableJsonTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System.IO;
+using System.Linq;
+using VeeamHealthCheck.Functions.Reporting.DataTypes;
+using VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Security;
+using VeeamHealthCheck.Shared;
+using VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.Security
+{
+    [Trait("Category", "Scrubbing")]
+    [Collection("GlobalState")]
+    public class CComplianceTableJsonTests : VbrTableScrubTestBase
+    {
+        // Minimal _SecurityCompliance.csv with two rows of different statuses.
+        private const string ComplianceCsv =
+            "\"Best Practice\",\"Status\"\r\n" +
+            "\"Backup Server is Up To Date\",\"Passed\"\r\n" +
+            "\"MFA is enabled\",\"Not Implemented\"";
+
+        // Minimal _SecurityComplianceMeta.csv required by the constructor.
+        private const string ComplianceMetaCsv =
+            "\"ScanStartedAt\",\"ScanCompletedAt\",\"ScanDurationSeconds\",\"ScanStatus\"\r\n" +
+            "\"2024-01-01T10:00:00\",\"2024-01-01T10:00:05\",\"5\",\"Completed\"";
+
+        public CComplianceTableJsonTests() : base("VhcComplianceJsonTests_")
+        {
+            CGlobals.FullReportJson = new CFullReportJson();
+        }
+
+        private void WriteComplianceCsvs()
+        {
+            File.WriteAllText(System.IO.Path.Combine(VbrDir, "_SecurityCompliance.csv"), ComplianceCsv);
+            File.WriteAllText(System.IO.Path.Combine(VbrDir, "_SecurityComplianceMeta.csv"), ComplianceMetaCsv);
+        }
+
+        [Fact]
+        public void ComplianceTable_PopulatesJsonSection_ComplianceTableKey()
+        {
+            WriteComplianceCsvs();
+            var ct = new CComplianceTable();
+            ct.ComplianceTable();
+
+            Assert.True(CGlobals.FullReportJson.Sections.ContainsKey("complianceTable"),
+                "Expected Sections[\"complianceTable\"] to be populated after ComplianceTable().");
+        }
+
+        [Fact]
+        public void ComplianceTable_JsonSection_HasExpectedHeaders()
+        {
+            WriteComplianceCsvs();
+            var ct = new CComplianceTable();
+            ct.ComplianceTable();
+
+            var section = CGlobals.FullReportJson.Sections["complianceTable"];
+            Assert.Equal(new[] { "Best Practice", "Status" }, section.Headers);
+        }
+
+        [Fact]
+        public void ComplianceTable_JsonSection_ContainsOneRowPerRule()
+        {
+            WriteComplianceCsvs();
+            var ct = new CComplianceTable();
+            ct.ComplianceTable();
+
+            var section = CGlobals.FullReportJson.Sections["complianceTable"];
+            Assert.Equal(2, section.Rows.Count);
+        }
+
+        [Fact]
+        public void ComplianceTable_JsonSection_RowsContainRawBestPracticeText()
+        {
+            WriteComplianceCsvs();
+            var ct = new CComplianceTable();
+            ct.ComplianceTable();
+
+            var section = CGlobals.FullReportJson.Sections["complianceTable"];
+            var bestPractices = section.Rows.Select(r => r[0]).ToList();
+
+            Assert.Contains("Backup Server is Up To Date", bestPractices);
+            Assert.Contains("MFA is enabled", bestPractices);
+        }
+
+        [Fact]
+        public void ComplianceTable_JsonSection_RowsContainRawStatusWithoutHtmlMarkup()
+        {
+            WriteComplianceCsvs();
+            var ct = new CComplianceTable();
+            ct.ComplianceTable();
+
+            var section = CGlobals.FullReportJson.Sections["complianceTable"];
+
+            // JSON rows must carry plain text, no badge <span> or NEW markup.
+            foreach (var row in section.Rows)
+            {
+                Assert.DoesNotContain("<span", row[1]);
+                Assert.DoesNotContain("badge", row[1]);
+            }
+
+            var statuses = section.Rows.Select(r => r[1]).ToList();
+            Assert.Contains("Passed", statuses);
+            Assert.Contains("Not Implemented", statuses);
+        }
+
+        [Fact]
+        public void ComplianceTable_JsonRows_DoNotContainNewBadgeMarkup()
+        {
+            // Even if a rule is unmapped (IsMapped == false), the JSON row must not contain
+            // the NEW badge HTML that appears in the HTML report.
+            WriteComplianceCsvs();
+            var ct = new CComplianceTable();
+            ct.ComplianceTable();
+
+            var section = CGlobals.FullReportJson.Sections["complianceTable"];
+            foreach (var row in section.Rows)
+            {
+                Assert.DoesNotContain("badge-new", row[0]);
+                Assert.DoesNotContain("NEW", row[0]);
+            }
+        }
+
+        [Fact]
+        public void ComplianceScan_MetadataStillPresentAfterComplianceTable()
+        {
+            // Verify the stable VIP-ingestion ComplianceScan property is unaffected by the change.
+            WriteComplianceCsvs();
+            var ct = new CComplianceTable();
+            ct.ComplianceTable();
+
+            Assert.NotNull(CGlobals.FullReportJson.ComplianceScan);
+            Assert.Equal(2, CGlobals.FullReportJson.ComplianceScan.RuleCount);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `credentials`, `userRoles`, `emailNotification`, and `complianceTable` sections to the JSON report (`*.json`), which were present in HTML but absent from JSON output
- Extends the fluent `CSectionTable<T>` builder with `JsonHeaders` and `BuildJsonRows()` (opt-in, no impact on existing callers)
- JSON rows carry raw values — no HTML badge markup or `NEW` spans

## Notes

- `complianceTable` section only emits when compliance CSV data is present (matches HTML behavior); consumers can fall back to `ComplianceScan.RuleCount == 0` for the empty case
- The stable `ComplianceScan` metadata object (VIP ingestion contract) is untouched

## Test Plan

- [ ] 5 new JSON facts in `CCredentialsTableScrubTests` — section key, headers, row count, scrub behavior, empty CSV
- [ ] 6 new JSON facts in `CUserRolesTableScrubTests` — section key, headers, row count, scrub, role not scrubbed, empty CSV
- [ ] 8 new tests in `CEmailNotificationTableTests` — HTML scrub + 5 JSON section facts
- [ ] 7 new tests in `CComplianceTableJsonTests` — section key, headers, row count, raw text, no badge markup, `ComplianceScan` unaffected
- [ ] CI (`dotnet test` on `windows-latest`) green

Fixes #169