### PR TITLE
fix(json): materialize EmailNotification CSV stream before Any() check

### DIFF
--- a/.github/workflows/pr-release-prep.yml
+++ b/.github/workflows/pr-release-prep.yml
@@ -87,3 +87,25 @@ jobs:
         echo "download_url=$downloadUrl" >> $env:GITHUB_OUTPUT
     
     # Commenting is handled by a separate safe workflow using pull_request_target
+
+  test-same-repo-pr:
+    runs-on: windows-latest
+    if: github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name
+
+    steps:
+    - name: Checkout PR code
+      uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore vHC/HC.sln
+
+    - name: Build solution
+      run: dotnet build vHC/HC.sln --configuration Release --no-restore
+
+    - name: Run tests
+      run: dotnet test vHC/HC.sln --configuration Release --no-build --verbosity normal

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
@@ -43,9 +43,9 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
             try
             {
                 CCsvParser c = new();
-                var data = c.GetDynamicEmailNotification();
+                var data = c.GetDynamicEmailNotification().ToList();
 
-                if (data == null || !data.Any())
+                if (!data.Any())
                 {
                     s += "<tr><td colspan='7' style='text-align: center; padding: 20px; color: #666;'><em>No email notification settings detected.</em></td></tr>";
                 }


### PR DESCRIPTION
## Summary

- Adds `.ToList()` to `GetDynamicEmailNotification()` in `CEmailNotificationTable.Render()`, materializing the CsvHelper stream before calling `Any()`
- Removes the now-redundant `data == null` check (`.ToList()` never returns null)
- Adds a `test-same-repo-pr` job to `pr-release-prep.yml` so the full Windows test suite runs on same-repo PRs, closing the gap that let this slip through

## Root Cause

`CsvHelper.GetRecords<dynamic>()` returns a lazy `IEnumerable` backed by a single `TextReader`. Calling `data.Any()` advanced the reader past the first (and only) row; the subsequent `foreach` then found the reader at EOF and yielded zero records — leaving JSON rows empty and the SMTP server absent from HTML output.

`CCredentialsTable` and `CUserRolesTable` already use `.ToList()` correctly; this brings `CEmailNotificationTable` into line.

## Why the CI gap existed

`pr-release-prep.yml` only ran its build+test job for fork PRs (external contributors). Same-repo branches had no pre-merge gate on `VhcXTests` — the only workflow that runs it (`ci-cd.yaml`) triggers on push to `dev`/`master`, not on PRs. The new `test-same-repo-pr` job closes that gap without the publish/zip/upload steps that are only relevant for external releases.

## Test Plan

- [ ] `CEmailNotificationTableTests.Render_ScrubFalse_ContainsSmtpServer` — previously failing, now passes
- [ ] `CEmailNotificationTableTests.Render_JsonSection_ContainsOneRowForOneCsvRecord` — previously failing, now passes
- [ ] `CEmailNotificationTableTests.Render_ScrubTrue_JsonSection_SmtpServerIsScrubbed` — previously failing, now passes
- [ ] All other `CEmailNotificationTableTests` remain green
- [ ] `test-same-repo-pr` job fires on this PR and goes green
- [ ] CI (`dotnet test` on `windows-latest`) green on dev after merge

Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)