### PR TITLE
fix(reporting): correct EmailNotification column names to match Veeam cmdlet output

### DIFF
--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTable.cs
@@ -26,13 +26,13 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
         {
             string s = this.form.SectionStartWithButton("emailnotification", "Email Notification", "Email Notification");
 
-            s += this.form.TableHeader("Is Enabled", string.Empty);
+            s += this.form.TableHeader("Enabled", string.Empty);
             s += this.form.TableHeader("SMTP Server", string.Empty);
-            s += this.form.TableHeader("From", string.Empty);
-            s += this.form.TableHeader("To", string.Empty);
+            s += this.form.TableHeader("Sender", string.Empty);
+            s += this.form.TableHeader("Recipient", string.Empty);
             s += this.form.TableHeader("Notify On Success", string.Empty);
             s += this.form.TableHeader("Notify On Warning", string.Empty);
-            s += this.form.TableHeader("Notify On Error", string.Empty);
+            s += this.form.TableHeader("Notify On Failure", string.Empty);
 
             s += this.form.TableHeaderEnd();
             s += this.form.TableBodyStart();
@@ -55,32 +55,33 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
                     {
                         s += "<tr>";
 
-                        string smtpServer = (string)(item.smtpserver ?? "");
-                        string fromAddr = (string)(item.from ?? "");
-                        string toAddr = (string)(item.to ?? "");
+                        var row = (IDictionary<string, object>)item;
+                        string enabled = row.TryGetValue("enabled", out var en) ? (string)(en ?? "") : "";
+                        string smtpServer = row.TryGetValue("smtpserver", out var sv) ? (string)(sv ?? "") : "";
+                        string sender = row.TryGetValue("sender", out var sn) ? (string)(sn ?? "") : "";
+                        string recipient = row.TryGetValue("recipient", out var rc) ? (string)(rc ?? "") : "";
+                        string notifySuccess = row.TryGetValue("notifyonsuccess", out var ns) ? (string)(ns ?? "") : "";
+                        string notifyWarning = row.TryGetValue("notifyonwarning", out var nw) ? (string)(nw ?? "") : "";
+                        string notifyFailure = row.TryGetValue("notifyonfailure", out var nf) ? (string)(nf ?? "") : "";
+
                         if (scrub)
                         {
                             smtpServer = CGlobals.Scrubber.ScrubItem(smtpServer, ScrubItemType.Server);
-                            fromAddr = CGlobals.Scrubber.ScrubItem(fromAddr, ScrubItemType.Item);
-                            toAddr = CGlobals.Scrubber.ScrubItem(toAddr, ScrubItemType.Item);
+                            sender = CGlobals.Scrubber.ScrubItem(sender, ScrubItemType.Item);
+                            recipient = CGlobals.Scrubber.ScrubItem(recipient, ScrubItemType.Item);
                         }
 
-                        string isEnabled = (string)(item.isenabled ?? "");
-                        string notifySuccess = (string)(item.notifyonsuccess ?? "");
-                        string notifyWarning = (string)(item.notifyonwarning ?? "");
-                        string notifyError = (string)(item.notifyonerror ?? "");
-
-                        s += this.form.TableData(isEnabled, string.Empty);
+                        s += this.form.TableData(enabled, string.Empty);
                         s += this.form.TableData(smtpServer, string.Empty);
-                        s += this.form.TableData(fromAddr, string.Empty);
-                        s += this.form.TableData(toAddr, string.Empty);
+                        s += this.form.TableData(sender, string.Empty);
+                        s += this.form.TableData(recipient, string.Empty);
                         s += this.form.TableData(notifySuccess, string.Empty);
                         s += this.form.TableData(notifyWarning, string.Empty);
-                        s += this.form.TableData(notifyError, string.Empty);
+                        s += this.form.TableData(notifyFailure, string.Empty);
 
                         s += "</tr>";
 
-                        jsonRows.Add(new List<string> { isEnabled, smtpServer, fromAddr, toAddr, notifySuccess, notifyWarning, notifyError });
+                        jsonRows.Add(new List<string> { enabled, smtpServer, sender, recipient, notifySuccess, notifyWarning, notifyFailure });
                     }
                 }
             }
@@ -93,7 +94,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.GeneralSetting
 
             CHtmlTables.SetSectionPublic(
                 "emailNotification",
-                new List<string> { "Is Enabled", "SMTP Server", "From", "To", "Notify On Success", "Notify On Warning", "Notify On Error" },
+                new List<string> { "Enabled", "SMTP Server", "Sender", "Recipient", "Notify On Success", "Notify On Warning", "Notify On Failure" },
                 jsonRows,
                 null);
 

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTableTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/GeneralSettings/CEmailNotificationTableTests.cs
@@ -14,9 +14,10 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
     public class CEmailNotificationTableTests : VbrTableScrubTestBase
     {
         // FileFinder matches "_EmailNotification.csv"; CsvHelper lowercases headers via
-        // PrepareHeaderForMatch, so dynamic properties are accessed as "smtpserver", "from", etc.
+        // PrepareHeaderForMatch, so dynamic properties are accessed as "enabled", "sender", etc.
+        // Column names match Get-VBRMailNotificationConfiguration output.
         private const string EmailNotificationCsv =
-            "\"IsEnabled\",\"SmtpServer\",\"From\",\"To\",\"NotifyOnSuccess\",\"NotifyOnWarning\",\"NotifyOnError\"\r\n" +
+            "\"Enabled\",\"SmtpServer\",\"Sender\",\"Recipient\",\"NotifyOnSuccess\",\"NotifyOnWarning\",\"NotifyOnFailure\"\r\n" +
             "\"True\",\"smtp.corp.example.com\",\"veeam@corp.example.com\",\"admin@corp.example.com\",\"False\",\"True\",\"True\"";
 
         public CEmailNotificationTableTests() : base("VhcEmailNotifTests_")
@@ -75,7 +76,7 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
 
             var section = CGlobals.FullReportJson.Sections["emailNotification"];
             Assert.Equal(
-                new List<string> { "Is Enabled", "SMTP Server", "From", "To", "Notify On Success", "Notify On Warning", "Notify On Error" },
+                new List<string> { "Enabled", "SMTP Server", "Sender", "Recipient", "Notify On Success", "Notify On Warning", "Notify On Failure" },
                 section.Headers);
         }
 
@@ -87,10 +88,10 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
 
             var section = CGlobals.FullReportJson.Sections["emailNotification"];
             Assert.Single(section.Rows);
-            Assert.Equal("True", section.Rows[0][0]);                       // Is Enabled
+            Assert.Equal("True", section.Rows[0][0]);                       // Enabled
             Assert.Equal("smtp.corp.example.com", section.Rows[0][1]);      // SMTP Server
-            Assert.Equal("veeam@corp.example.com", section.Rows[0][2]);     // From
-            Assert.Equal("admin@corp.example.com", section.Rows[0][3]);     // To
+            Assert.Equal("veeam@corp.example.com", section.Rows[0][2]);     // Sender
+            Assert.Equal("admin@corp.example.com", section.Rows[0][3]);     // Recipient
         }
 
         [Fact]
@@ -108,7 +109,7 @@ namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.GeneralSettings
         public void Render_EmptyData_JsonSection_StillPresentWithZeroRows()
         {
             File.WriteAllText(System.IO.Path.Combine(VbrDir, "_EmailNotification.csv"),
-                "\"IsEnabled\",\"SmtpServer\",\"From\",\"To\",\"NotifyOnSuccess\",\"NotifyOnWarning\",\"NotifyOnError\"\r\n");
+                "\"Enabled\",\"SmtpServer\",\"Sender\",\"Recipient\",\"NotifyOnSuccess\",\"NotifyOnWarning\",\"NotifyOnFailure\"\r\n");
             new CEmailNotificationTable().Render(scrub: false);
 
             Assert.True(CGlobals.FullReportJson.Sections.ContainsKey("emailNotification"));


### PR DESCRIPTION
## Summary

- Corrects the CSV column names used to read `_EmailNotification.csv` — they were assumed based on guesswork and didn't match the actual `Get-VBRMailNotificationConfiguration` output
- Switches to `IDictionary<string,object>` / `TryGetValue` access (matching `CUserRolesTable`) to avoid future `RuntimeBinderException` if a column is absent
- Updates test CSV headers and assertions to reflect reality

## Column name mapping

| Was (wrong) | Now (correct) |
|---|---|
| `IsEnabled` / `isenabled` | `Enabled` / `enabled` |
| `SmtpServer` / `smtpserver` | unchanged ✓ |
| `From` / `from` | `Sender` / `sender` |
| `To` / `to` | `Recipient` / `recipient` |
| `NotifyOnSuccess` / `notifyonsuccess` | unchanged ✓ |
| `NotifyOnWarning` / `notifyonwarning` | unchanged ✓ |
| `NotifyOnError` / `notifyonerror` | `NotifyOnFailure` / `notifyonfailure` |

## Root cause

The original scaffolding guessed column names. Tests were written to match the code — circular validation that never touched the real Veeam cmdlet output. No upstream consumers of the `emailNotification` JSON section exist yet, so renaming the headers is safe.

Issue #173 proposed fixing this by adding a `Select-Object` alias in the PowerShell collection script to rename the real columns back to the wrong C# names. This PR takes the better approach: fix the C# to match the real cmdlet output, keeping the PowerShell clean.

## Test Plan

- [ ] All `CEmailNotificationTableTests` green
- [ ] `test-same-repo-pr` CI job green
- [ ] Manually verify Email Notification section renders correctly in HTML/JSON against a real VBR instance

Fixes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)