### PR TITLE
Also fail on Pester block/container failures (not just failed tests)

### DIFF
--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Validation/E2E/Invoke-VhcE2E.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Validation/E2E/Invoke-VhcE2E.ps1
@@ -144,7 +144,7 @@ function Invoke-Tests {
         $cfg.Filter.ExcludeTag = 'LiveVBR'
         $cfg.Output.Verbosity  = 'None'
         $pr = Invoke-Pester -Configuration $cfg
-        Add-Result (New-VhcE2EResult 'Tests:Pester' ($pr.FailedCount -eq 0) "$($pr.PassedCount) passed, $($pr.FailedCount) failed, $($pr.SkippedCount) skipped")
+        Add-Result (New-VhcE2EResult 'Tests:Pester' (($pr.FailedCount + $pr.FailedBlocksCount + $pr.FailedContainersCount) -eq 0) "$($pr.PassedCount) passed, $($pr.FailedCount) failed, $($pr.SkippedCount) skipped")
     } catch {
         Add-Result (New-VhcE2EResult 'Tests:Pester' $false "Pester run error: $($_.Exception.Message)")
     }


### PR DESCRIPTION
> ⚠️ This PR was generated by an AI agent (GitHub Copilot CLI). Please review accordingly.

I've been seeing this commonly across Pester 5 build scripts and I'm fixing it where it looks like it could hide real failures.

In Pester 5 a run reports three independent failure counts:

- `FailedCount` — failed tests (`It`)
- `FailedBlocksCount` — failed `BeforeAll` / `AfterAll`
- `FailedContainersCount` — files that error during discovery / fail to load

Gating on only `FailedCount` means a `BeforeAll` that throws, or a test file that fails to load, leaves `FailedCount = 0` and the build passes green despite real failures. Pester itself derives the overall pass/fail from the sum of all three.

This change includes all three counts in the gate. Display/log messages are left unchanged.
