### PR TITLE
fix(collection): gate -ForceAcceptTlsCertificate to VBR v13+ (v12 regression, #149)

### DIFF
--- a/vHC/HC_Reporting/Functions/Collection/CCollections.cs
+++ b/vHC/HC_Reporting/Functions/Collection/CCollections.cs
@@ -46,16 +46,22 @@ namespace VeeamHealthCheck.Functions.Collection
 
         /// <summary>
         /// Builds the PowerShell script for the local (Windows-auth) VBR MFA pre-check.
-        /// <c>-ForceAcceptTlsCertificate</c> is REQUIRED: on VBR v13 a self-signed / untrusted
-        /// server certificate makes Connect-VBRServer raise an interactive trust prompt that can
-        /// never be answered when the process runs headless (CreateNoWindow, no stdin), hanging
-        /// the collection forever (issue #149). This mirrors the remote path in TestMfa.ps1, which
-        /// already passes the flag. <c>-ErrorAction Stop</c> makes a failed connect surface as a
-        /// non-zero exit code rather than a silent success.
+        /// <c>-ForceAcceptTlsCertificate</c> is added ONLY for VBR v13+ (the parameter does not
+        /// exist on v12): on v13 a self-signed / untrusted server certificate makes Connect-VBRServer
+        /// raise an interactive trust prompt that can never be answered when the process runs headless
+        /// (CreateNoWindow, no stdin), hanging the collection forever (issue #149). <c>-ErrorAction
+        /// Stop</c> makes a failed connect surface as a non-zero exit code rather than a silent success.
         /// </summary>
-        internal static string BuildLocalMfaConnectScript() =>
-            "Import-Module Veeam.Backup.PowerShell -WarningAction Ignore; " +
-            "Connect-VBRServer -Server localhost -ForceAcceptTlsCertificate -ErrorAction Stop";
+        internal static string BuildLocalMfaConnectScript(int vbrMajorVersion)
+        {
+            // -ForceAcceptTlsCertificate ONLY exists on VBR v13+. Passing it to v12's
+            // Connect-VBRServer throws "A parameter cannot be found that matches parameter
+            // name 'ForceAcceptTlsCertificate'" and breaks collection, so include it only for
+            // v13+ — which is also the only version where the untrusted-cert prompt hangs (#149).
+            string certFlag = vbrMajorVersion >= 13 ? " -ForceAcceptTlsCertificate" : string.Empty;
+            return "Import-Module Veeam.Backup.PowerShell -WarningAction Ignore; " +
+                   $"Connect-VBRServer -Server localhost{certFlag} -ErrorAction Stop";
+        }
 
         /// <summary>
         /// Starts a PowerShell process from <paramref name="startInfo"/> and runs it under a hard
@@ -451,7 +457,7 @@ namespace VeeamHealthCheck.Functions.Collection
 
                 // Build PowerShell arguments with Base64-encoded password
                 // Use double quotes around Base64 string to avoid issues with special characters
-                string args = $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\" -Server \"{escapedServer}\" -Username \"{escapedUser}\" -PasswordBase64 \"{base64Password}\"";
+                string args = $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\" -Server \"{escapedServer}\" -Username \"{escapedUser}\" -PasswordBase64 \"{base64Password}\" -VBRVersion {CGlobals.VBRMAJORVERSION}";
 
                 var processInfo = new ProcessStartInfo
                 {
@@ -464,11 +470,11 @@ namespace VeeamHealthCheck.Functions.Collection
                 };
 
                 // Log processInfo settings - construct safe log message without ever including sensitive data
-                string safeArgs = $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\" -Server \"{escapedServer}\" -Username \"{escapedUser}\" -PasswordBase64 \"****\"";
+                string safeArgs = $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\" -Server \"{escapedServer}\" -Username \"{escapedUser}\" -PasswordBase64 \"****\" -VBRVersion {CGlobals.VBRMAJORVERSION}";
                 CGlobals.Logger.Debug($"ProcessStartInfo Settings:\n  FileName: {processInfo.FileName}\n  Arguments: {safeArgs}\n  RedirectStandardOutput: {processInfo.RedirectStandardOutput}\n  RedirectStandardError: {processInfo.RedirectStandardError}\n  UseShellExecute: {processInfo.UseShellExecute}\n  CreateNoWindow: {processInfo.CreateNoWindow}");
                 // Run under a bounded timeout with async reads so an interactive prompt or a full
-                // pipe buffer cannot hang the remote MFA check forever (issue #149 defense-in-depth;
-                // TestMfa.ps1 already passes -ForceAcceptTlsCertificate, so no script change here).
+                // pipe buffer cannot hang the remote MFA check forever (issue #149 defense-in-depth).
+                // The cert flag is handled inside TestMfa.ps1, gated on the -VBRVersion we pass above.
                 RunBoundedPowerShell(
                     processInfo,
                     MfaCheckTimeoutSeconds,
@@ -649,11 +655,11 @@ namespace VeeamHealthCheck.Functions.Collection
                     psExe = "powershell.exe";
                 }
 
-                // Simple Connect-VBRServer without credentials.
-                // NOTE: the script MUST include -ForceAcceptTlsCertificate — without it, VBR v13
-                // prompts to accept the server certificate and this headless process hangs forever
-                // (issue #149). The connect string is built by BuildLocalMfaConnectScript().
-                string script = BuildLocalMfaConnectScript();
+                // Simple Connect-VBRServer without credentials. On VBR v13 the connect string adds
+                // -ForceAcceptTlsCertificate (built by BuildLocalMfaConnectScript, gated by version)
+                // to avoid the headless cert-prompt hang; on v12 that flag is omitted because the
+                // parameter does not exist there and would break the connect (issue #149).
+                string script = BuildLocalMfaConnectScript(CGlobals.VBRMAJORVERSION);
                 string args = $"-NoProfile -ExecutionPolicy Bypass -Command \"{script}\"";
 
                 CGlobals.Logger.Debug($"[Local MFA Check] Running local MFA check with Windows auth: {psExe} -Command \"{script}\"");

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
@@ -244,15 +244,19 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
 
         /// <summary>
         /// Builds the PowerShell command line for the remote / PS5-failover VBR MFA check.
-        /// <c>-ForceAcceptTlsCertificate</c> is REQUIRED (issue #149): without it VBR v13 raises an
-        /// interactive server-certificate trust prompt that hangs this headless process forever.
+        /// <c>-ForceAcceptTlsCertificate</c> is added ONLY for VBR v13+ (the parameter does not exist
+        /// on v12, where it throws and breaks the connect): on v13 it suppresses the interactive
+        /// server-certificate trust prompt that would otherwise hang this headless process (issue #149).
         /// <c>-ErrorAction Stop</c> makes a failed connect surface as a non-zero exit. Callers MUST
         /// pass values already escaped for a single-quoted PowerShell context via
         /// <see cref="CredentialHelper.EscapeForPowerShellSingleQuotes"/>.
         /// </summary>
-        internal static string BuildRemoteMfaConnectArgs(string escapedServer, string escapedUser, string escapedPassword) =>
-            $"Import-Module Veeam.Backup.PowerShell; Connect-VBRServer -Server '{escapedServer}' " +
-            $"-User '{escapedUser}' -Password '{escapedPassword}' -ForceAcceptTlsCertificate -ErrorAction Stop";
+        internal static string BuildRemoteMfaConnectArgs(string escapedServer, string escapedUser, string escapedPassword, int vbrMajorVersion)
+        {
+            string certFlag = vbrMajorVersion >= 13 ? " -ForceAcceptTlsCertificate" : string.Empty;
+            return $"Import-Module Veeam.Backup.PowerShell; Connect-VBRServer -Server '{escapedServer}' " +
+                   $"-User '{escapedUser}' -Password '{escapedPassword}'{certFlag} -ErrorAction Stop";
+        }
 
         public bool TestMfa()
         {
@@ -277,9 +281,9 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
                 ProcessStartInfo startInfo = new ProcessStartInfo
                 {
                     FileName = "powershell.exe",
-                    // Args (incl. the REQUIRED -ForceAcceptTlsCertificate for issue #149) are built
-                    // by BuildRemoteMfaConnectArgs; server/user/password are single-quote escaped above.
-                    Arguments = BuildRemoteMfaConnectArgs(escapedServer, escapedUser, escapedPassword),
+                    // Args (incl. -ForceAcceptTlsCertificate for v13+ only, issue #149) are built by
+                    // BuildRemoteMfaConnectArgs; server/user/password are single-quote escaped above.
+                    Arguments = BuildRemoteMfaConnectArgs(escapedServer, escapedUser, escapedPassword, CGlobals.VBRMAJORVERSION),
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
@@ -290,8 +294,10 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
                 // BuildRemoteMfaConnectArgs) on purpose: if the real-password call and the masked-log
                 // call share one method, CodeQL's interprocedural taint summary treats the masked log
                 // as carrying the real password (cs/cleartext-storage false positive). Keeping them
-                // separate keeps the real password provably off every logging path.
-                string safeLogArgs = $"Import-Module Veeam.Backup.PowerShell; Connect-VBRServer -Server '{escapedServer}' -User '{escapedUser}' -Password '****' -ForceAcceptTlsCertificate -ErrorAction Stop";
+                // separate keeps the real password provably off every logging path. The cert flag
+                // mirrors the real args (v13+ only — it does not exist on v12).
+                string certFlag = CGlobals.VBRMAJORVERSION >= 13 ? " -ForceAcceptTlsCertificate" : string.Empty;
+                string safeLogArgs = $"Import-Module Veeam.Backup.PowerShell; Connect-VBRServer -Server '{escapedServer}' -User '{escapedUser}' -Password '****'{certFlag} -ErrorAction Stop";
                 CGlobals.Logger.Info("[TestMfa] Arguments: " + safeLogArgs);
 
                 this.log.Info($"[TestMfa] Creating ProcessStartInfo for MFA test:");

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/Scripts/TestMfa.ps1
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/Scripts/TestMfa.ps1
@@ -4,7 +4,9 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$Username = '',
     [Parameter(Mandatory = $false)]
-    [string]$PasswordBase64 = ''
+    [string]$PasswordBase64 = '',
+    [Parameter(Mandatory = $false)]
+    [int]$VBRVersion = 0
 )
 
 # Suppress ANSI color codes in PS7+ so stderr is always plain text
@@ -123,8 +125,12 @@ if ($MyInvocation.InvocationName -ne '.') {
         Write-Host "[VERBOSE] Username: $Username"
 
         # Use -User and -Password parameters directly (same as manual CLI usage)
-        # This approach works better for local accounts vs -Credential
-        Connect-VBRServer -Server $Server -User $Username -Password $password -ForceAcceptTlsCertificate -ErrorAction Stop
+        # This approach works better for local accounts vs -Credential.
+        # -ForceAcceptTlsCertificate only exists on VBR v13+; gate by version so v12 (where the
+        # parameter does not exist and would throw) still connects (issue #149 v12-regression guard).
+        $certParam = @{}
+        if ($VBRVersion -ge 13) { $certParam['ForceAcceptTlsCertificate'] = $true }
+        Connect-VBRServer -Server $Server -User $Username -Password $password @certParam -ErrorAction Stop
         Write-Host "[VERBOSE] Successfully connected to VBR Server."
         exit 0
     }

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-VBRConfig.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-VBRConfig.ps1
@@ -157,6 +157,11 @@ $useCreds = (-not [string]::IsNullOrWhiteSpace($User) -and
 # even if a prerequisite collector aborts the run early.
 try {
     Write-StartupLog "Connecting to VBR server '$VBRServer' (useCreds=$useCreds)..."
+    # -ForceAcceptTlsCertificate only exists on VBR v13+; passing it on v12 throws
+    # "A parameter cannot be found that matches parameter name 'ForceAcceptTlsCertificate'"
+    # and aborts collection. Gate it by version (issue #149 v12-regression guard).
+    $certParam = @{}
+    if ($VBRVersion -ge 13) { $certParam['ForceAcceptTlsCertificate'] = $true }
     if ($useCreds) {
         if (-not [string]::IsNullOrWhiteSpace($PasswordBase64)) {
             $passwordBytes = [System.Convert]::FromBase64String($PasswordBase64)
@@ -166,12 +171,9 @@ try {
         }
         $securePassword = ConvertTo-SecureString -String $plainPassword -AsPlainText -Force
         $credential     = New-Object System.Management.Automation.PSCredential($User, $securePassword)
-        Connect-VBRServer -Server $VBRServer -Credential $credential -ForceAcceptTlsCertificate -ErrorAction Stop
+        Connect-VBRServer -Server $VBRServer -Credential $credential @certParam -ErrorAction Stop
     } else {
-        # -ForceAcceptTlsCertificate is REQUIRED: on VBR v13 an untrusted server cert
-        # otherwise raises an interactive trust prompt that hangs this headless
-        # collection forever (issue #149) - the same hang the MFA pre-check guards against.
-        Connect-VBRServer -Server $VBRServer -ForceAcceptTlsCertificate -ErrorAction Stop
+        Connect-VBRServer -Server $VBRServer @certParam -ErrorAction Stop
     }
     Write-StartupLog "Connected to VBR server '$VBRServer'."
 

--- a/vHC/VhcXTests/LocalMfaConnectScriptTests.cs
+++ b/vHC/VhcXTests/LocalMfaConnectScriptTests.cs
@@ -11,44 +11,48 @@ namespace VhcXTests
     /// Issue #149: on VBR v13, an untrusted / self-signed server certificate makes
     /// Connect-VBRServer raise an interactive "accept this certificate?" prompt. The MFA
     /// pre-check runs PowerShell headless (CreateNoWindow, no stdin), so the prompt can
-    /// never be answered and the whole collection hangs forever — exactly the symptom in
-    /// the reported screenshot (frozen at "Local VBR detected, using Windows authentication").
+    /// never be answered and the whole collection hangs forever.
     ///
-    /// The remote path (TestMfa.ps1) already passed -ForceAcceptTlsCertificate; the local
-    /// path (CCollections.RunLocalMfaCheckNoCredentials) was missing it. These tests trap
-    /// that class of bug at the script-construction seam so it cannot silently regress.
+    /// The fix adds -ForceAcceptTlsCertificate — but ONLY for v13+, because that parameter
+    /// does not exist on VBR v12's Connect-VBRServer (passing it there throws
+    /// "A parameter cannot be found..." and breaks collection). These tests pin both halves
+    /// of that contract: present on v13+, absent on v12.
     /// </summary>
     [Trait("Category", "Regression")]
     public class LocalMfaConnectScriptTests
     {
-        [Fact]
-        public void BuildLocalMfaConnectScript_ForcesTlsCertificateAcceptance_Issue149()
+        [Theory]
+        [InlineData(13)]
+        [InlineData(14)]
+        public void BuildLocalMfaConnectScript_V13Plus_ForcesTlsCertificateAcceptance_Issue149(int major)
         {
-            string script = CCollections.BuildLocalMfaConnectScript();
-
+            string script = CCollections.BuildLocalMfaConnectScript(major);
             // Without this flag VBR v13 prompts to accept the server certificate and the
-            // headless collection hangs forever (issue #149). This is the core regression guard.
+            // headless collection hangs forever (issue #149).
             Assert.Contains("-ForceAcceptTlsCertificate", script);
         }
 
-        [Fact]
-        public void BuildLocalMfaConnectScript_StopsOnError()
+        [Theory]
+        [InlineData(12)]
+        [InlineData(0)]
+        public void BuildLocalMfaConnectScript_V12OrUnknown_OmitsTlsFlag_NoParamNotFound(int major)
         {
-            string script = CCollections.BuildLocalMfaConnectScript();
-
-            // -ErrorAction Stop makes a failed connect surface as a non-zero exit code
-            // rather than a silent "success" the caller would misread.
-            Assert.Contains("-ErrorAction Stop", script);
+            string script = CCollections.BuildLocalMfaConnectScript(major);
+            // -ForceAcceptTlsCertificate does not exist on v12's Connect-VBRServer; including it
+            // throws NamedParameterNotFound and breaks collection. Must be absent below v13.
+            Assert.DoesNotContain("-ForceAcceptTlsCertificate", script);
         }
 
-        [Fact]
-        public void BuildLocalMfaConnectScript_ConnectsToLocalhostViaVeeamModule()
+        [Theory]
+        [InlineData(12)]
+        [InlineData(13)]
+        public void BuildLocalMfaConnectScript_AlwaysConnectsLocalhostAndStopsOnError(int major)
         {
-            string script = CCollections.BuildLocalMfaConnectScript();
-
+            string script = CCollections.BuildLocalMfaConnectScript(major);
             Assert.Contains("Import-Module Veeam.Backup.PowerShell", script);
             Assert.Contains("Connect-VBRServer", script);
             Assert.Contains("-Server localhost", script);
+            Assert.Contains("-ErrorAction Stop", script);
         }
 
         [Fact]

--- a/vHC/VhcXTests/RemoteMfaConnectArgsTests.cs
+++ b/vHC/VhcXTests/RemoteMfaConnectArgsTests.cs
@@ -10,34 +10,41 @@ namespace VhcXTests
     /// (PSInvoker.BuildRemoteMfaConnectArgs). Companion to LocalMfaConnectScriptTests.
     ///
     /// Issue #149: the MFA check runs Connect-VBRServer headless; on VBR v13 an untrusted
-    /// server certificate raises an interactive trust prompt that hangs forever. The flag
-    /// was missing from this credentialed path before the fix, so these guards trap its
-    /// removal (RED against the pre-fix inline string, GREEN after).
+    /// server certificate raises an interactive trust prompt that hangs forever. The fix adds
+    /// -ForceAcceptTlsCertificate for v13+ only — the parameter does not exist on v12, where
+    /// passing it throws NamedParameterNotFound and breaks the connect.
     /// </summary>
     [Trait("Category", "Regression")]
     public class RemoteMfaConnectArgsTests
     {
-        [Fact]
-        public void BuildRemoteMfaConnectArgs_ForcesTlsCertificateAcceptance_Issue149()
+        [Theory]
+        [InlineData(13)]
+        [InlineData(14)]
+        public void BuildRemoteMfaConnectArgs_V13Plus_ForcesTlsCertificateAcceptance_Issue149(int major)
         {
-            string args = PSInvoker.BuildRemoteMfaConnectArgs("srv", "user", "pw");
+            string args = PSInvoker.BuildRemoteMfaConnectArgs("srv", "user", "pw", major);
             Assert.Contains("-ForceAcceptTlsCertificate", args);
         }
 
-        [Fact]
-        public void BuildRemoteMfaConnectArgs_StopsOnError_SoFailureSurfacesAsNonZeroExit()
+        [Theory]
+        [InlineData(12)]
+        [InlineData(0)]
+        public void BuildRemoteMfaConnectArgs_V12OrUnknown_OmitsTlsFlag_NoParamNotFound(int major)
         {
-            string args = PSInvoker.BuildRemoteMfaConnectArgs("srv", "user", "pw");
-            Assert.Contains("-ErrorAction Stop", args);
+            string args = PSInvoker.BuildRemoteMfaConnectArgs("srv", "user", "pw", major);
+            Assert.DoesNotContain("-ForceAcceptTlsCertificate", args);
         }
 
-        [Fact]
-        public void BuildRemoteMfaConnectArgs_KeepsServerUserPasswordSingleQuoted()
+        [Theory]
+        [InlineData(12)]
+        [InlineData(13)]
+        public void BuildRemoteMfaConnectArgs_AlwaysStopsOnErrorAndSingleQuotesFields(int major)
         {
-            // The three operator-supplied fields must remain inside single quotes — escaping is
-            // CredentialHelper's job upstream; this pins the quoting context so a future refactor
-            // can't silently drop it and reopen an argument-injection vector.
-            string args = PSInvoker.BuildRemoteMfaConnectArgs("srv", "user", "pw");
+            // -ErrorAction Stop surfaces failures as a non-zero exit; the three operator-supplied
+            // fields stay inside single quotes (escaping is CredentialHelper's job upstream) so a
+            // refactor cannot silently drop the quoting and reopen an injection vector.
+            string args = PSInvoker.BuildRemoteMfaConnectArgs("srv", "user", "pw", major);
+            Assert.Contains("-ErrorAction Stop", args);
             Assert.Contains("-Server 'srv'", args);
             Assert.Contains("-User 'user'", args);
             Assert.Contains("-Password 'pw'", args);


### PR DESCRIPTION
## Summary

Fixes a **VBR v12 regression** introduced by the #149 hang fix (merged in #180). The fix added `-ForceAcceptTlsCertificate` to `Connect-VBRServer`, but that parameter **only exists on VBR v13+**. On v12 it throws:

```
Connect-VBRServer : A parameter cannot be found that matches parameter name 'ForceAcceptTlsCertificate'.
+ FullyQualifiedErrorId : NamedParameterNotFound,...ConnectVBRServer
```

This broke the local MFA pre-check (and would break config collection) on v12 — caught by the `[self-hosted, vbr-v12]` integration job on `dev` ([failed run](https://github.com/VeeamHub/veeam-healthcheck/actions/runs/29845776295/job/88687375772)). It didn't surface in #180's PR CI because the Windows unit tests don't hit a live v12 `Connect-VBRServer`, and the self-hosted v12 job only runs on push to `dev`.

`Fixes #149`

### 🐛 Bug Fixes

- fix(collection): gate `-ForceAcceptTlsCertificate` to VBR v13+ so v12 collection no longer fails with `NamedParameterNotFound`

## Root cause

`-ForceAcceptTlsCertificate` is a v13+ addition to `Connect-VBRServer`. v12 doesn't have it — and doesn't need it (no mandatory cert-trust prompt there). The #149 fix applied it unconditionally.

## Fix — gate on VBR major version ≥ 13 at every site

| Site | Change |
|------|--------|
| `CCollections.BuildLocalMfaConnectScript` | now takes `int vbrMajorVersion`; flag added only for ≥ 13 |
| `PSInvoker.BuildRemoteMfaConnectArgs` | now takes `int vbrMajorVersion`; flag gated (+ masked-log literal gated to match) |
| `Get-VBRConfig.ps1` | conditional splat `@certParam` on `$VBRVersion` for both `Connect-VBRServer` calls |
| `TestMfa.ps1` | new `-VBRVersion` param; flag gated; C# `MfaTestPassed` now passes `-VBRVersion {VBRMAJORVERSION}` |

**Behavior:** v12 omits the flag (the original, working behavior); v13+ keeps it (the #149 hang fix). `CGlobals.VBRMAJORVERSION` is set from the registry during init, before the MFA check runs.

## Tests

`LocalMfaConnectScriptTests` and `RemoteMfaConnectArgsTests` now assert both halves of the contract:
- **v13/v14** → `-ForceAcceptTlsCertificate` **present**
- **v12/0 (unknown)** → **absent** (the regression guard)

## Verification

- Windows unit tests run on this PR (`test-same-repo-pr`).
- **The real gate is the `[self-hosted, vbr-v12]` job, which only runs on push to `dev`** — so the v12 fix is confirmed after merge, on the same runner that caught the regression. A v13 self-hosted job also runs, confirming the hang fix still holds.
