### PR TITLE
fix(collection): detect PowerShell version below VBR module requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Collection → Processing/Analysis → Report Generation
 - Multi-source collection: PowerShell scripts, SQL queries, registry reads, log parsing, WMI
 - PowerShell scripts in `Tools/Scripts/HealthCheck/VBR/` and `Tools/Scripts/HealthCheck/VB365/`
 - Outputs CSV files to `C:\temp\vHC\Original\{VBR|VB365}\{servername}\{timestamp}\`
+- **`CGlobals.REMOTEEXEC` does not mean scripts run on the remote server.** vHC always launches `pwsh.exe` and the `Veeam.Backup.PowerShell` module on the *local* machine; `REMOTEEXEC` only changes which server the module connects to (`-Server` / `-VBOServerFqdnOrIp`) and whether explicit credentials are required instead of Windows auth. Any preflight check on the local PowerShell/module install (e.g. version checks) must run regardless of `REMOTEEXEC` — it is never "the remote machine's problem."
 
 **Report Generation** (`Functions/Reporting/`)
 - `Functions/Reporting/Html/VBR/CHtmlCompiler.cs` - VBR report compiler

--- a/vHC/HC_Reporting/Common/CGlobals.cs
+++ b/vHC/HC_Reporting/Common/CGlobals.cs
@@ -48,7 +48,18 @@ namespace VeeamHealthCheck.Shared
         public static string VbrConsoleInstallDir;
         public static int PowerShellVersion;
         public static DateTime TOOLSTART;
+
+        /// <summary>
+        /// True when targeting a VBR/VB365 server other than the local machine (set via /remote
+        /// /host=&lt;name&gt;). Despite the name, this does NOT mean PowerShell scripts execute on
+        /// that remote machine - vHC always launches pwsh.exe and the Veeam.Backup.PowerShell
+        /// module locally. REMOTEEXEC only changes which server the module connects to (via
+        /// -Server / -VBOServerFqdnOrIp) and whether explicit credentials are required instead
+        /// of Windows auth. See <see cref="REMOTEHOST"/>.
+        /// </summary>
         public static bool REMOTEEXEC = false;
+
+        /// <summary>The server to connect to when <see cref="REMOTEEXEC"/> is true.</summary>
         public static string REMOTEHOST = string.Empty;
         public static bool GUIEXEC = false;
         private static string _runTimestamp = null;

--- a/vHC/HC_Reporting/Common/CGlobals.cs
+++ b/vHC/HC_Reporting/Common/CGlobals.cs
@@ -39,6 +39,13 @@ namespace VeeamHealthCheck.Shared
         public static string IMPORT_PATH = null;
         public static int VBRMAJORVERSION;
         public static string VBRFULLVERSION;
+
+        /// <summary>
+        /// Directory containing the VBR Console installation (e.g. ".../Backup and Replication/Console"),
+        /// resolved by <see cref="Functions.Collection.DB.CRegReader.GetVbrVersionFilePath"/>. Used to locate
+        /// the Veeam.Backup.PowerShell module manifest for the PowerShell version preflight check.
+        /// </summary>
+        public static string VbrConsoleInstallDir;
         public static int PowerShellVersion;
         public static DateTime TOOLSTART;
         public static bool REMOTEEXEC = false;

--- a/vHC/HC_Reporting/Common/CMessages.cs
+++ b/vHC/HC_Reporting/Common/CMessages.cs
@@ -92,6 +92,7 @@ UNATTENDED / SILENT MODE:
     5  Host unreachable
     6  /credfile= invalid (malformed JSON, missing fields, bad Base64)
     7  No Veeam product detected and no /host= provided
+    8  Installed PowerShell version is below what the VBR PowerShell module requires
 
   Worked example (Task Scheduler / 20-server fleet):
     Seed once on each server as the service account:

--- a/vHC/HC_Reporting/Common/SilentExit.cs
+++ b/vHC/HC_Reporting/Common/SilentExit.cs
@@ -26,6 +26,7 @@ namespace VeeamHealthCheck.Shared
         public const int HostUnreachable = 5;
         public const int BadCredFile = 6;
         public const int NoProductDetected = 7;
+        public const int PowerShellVersionUnsupported = 8;
 
         /// <summary>
         /// Used at silent-mode failure call sites that return an exit code

--- a/vHC/HC_Reporting/Functions/Collection/DB/CRegReader.cs
+++ b/vHC/HC_Reporting/Functions/Collection/DB/CRegReader.cs
@@ -106,6 +106,12 @@ namespace VeeamHealthCheck.Functions.Collection.DB
                 using (RegistryKey key =
                     Registry.LocalMachine.OpenSubKey("Software\\Veeam\\Veeam Mount Service"))
                 {
+                    if (key == null)
+                    {
+                        this.log.Error(this.logStart + "Failed to get VBR Core path from Mount Service registry key.");
+                        return null;
+                    }
+
                     var keyValue = key.GetValue("InstallationPath");
                     string path = string.Empty;
                     if (keyValue != null)
@@ -118,7 +124,14 @@ namespace VeeamHealthCheck.Functions.Collection.DB
                         return null;
                     }
 
-                    var version = FileVersionInfo.GetVersionInfo(path + "\\Veeam.Backup.Core.dll");
+                    string mountServiceVersionFilePath = path + "\\Veeam.Backup.Core.dll";
+                    if (!File.Exists(mountServiceVersionFilePath))
+                    {
+                        this.log.Error(this.logStart + "VBR Core DLL not found at Mount Service path: " + mountServiceVersionFilePath);
+                        return null;
+                    }
+
+                    var version = FileVersionInfo.GetVersionInfo(mountServiceVersionFilePath);
                     CGlobals.VBRFULLVERSION = version.FileVersion;
                     CGlobals.VbrConsoleInstallDir = this.ResolveConsoleInstallDir(path);
                     this.ParseVbrMajorVersion(CGlobals.VBRFULLVERSION);

--- a/vHC/HC_Reporting/Functions/Collection/DB/CRegReader.cs
+++ b/vHC/HC_Reporting/Functions/Collection/DB/CRegReader.cs
@@ -118,11 +118,9 @@ namespace VeeamHealthCheck.Functions.Collection.DB
                         return null;
                     }
 
-                    // string path = key.GetValue("CorePath").ToString();
-                    // FileInfo dllInfo = new FileInfo(path + "\\Packages\\VeeamDeploymentDll.dll");
                     var version = FileVersionInfo.GetVersionInfo(path + "\\Veeam.Backup.Core.dll");
                     CGlobals.VBRFULLVERSION = version.FileVersion;
-                    CGlobals.VbrConsoleInstallDir = path;
+                    CGlobals.VbrConsoleInstallDir = this.ResolveConsoleInstallDir(path);
                     this.ParseVbrMajorVersion(CGlobals.VBRFULLVERSION);
                     return CGlobals.VBRFULLVERSION;
                 }
@@ -151,6 +149,43 @@ namespace VeeamHealthCheck.Functions.Collection.DB
                     throw;
                 }
             }
+        }
+
+        /// <summary>
+        /// Resolves the Console\ directory when only a sibling component's install path is known.
+        /// The Mount Service's own InstallationPath does not reliably indicate where Console lives
+        /// (confirmed on live VBR servers: Mount Service always installs under Common Files,
+        /// independent of the drive VBR itself was installed to), so CorePath - which does track the
+        /// actual install drive - is tried first, with Mount Service only as a last-resort candidate.
+        /// Every candidate is validated with Directory.Exists before being trusted.
+        /// </summary>
+        private string ResolveConsoleInstallDir(string mountServiceInstallationPath)
+        {
+            string corePath = null;
+            try
+            {
+                using RegistryKey coreKey = Registry.LocalMachine.OpenSubKey("Software\\Veeam\\Veeam Backup and Replication");
+                corePath = coreKey?.GetValue("CorePath")?.ToString();
+            }
+            catch (Exception ex)
+            {
+                this.log.Debug(this.logStart + "CorePath registry probe missed: " + ex.Message);
+            }
+
+            foreach (string candidate in new[]
+            {
+                CVbrConsolePathResolver.SiblingConsoleDir(corePath),
+                CVbrConsolePathResolver.SiblingConsoleDir(mountServiceInstallationPath)
+            })
+            {
+                if (!string.IsNullOrEmpty(candidate) && Directory.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            this.log.Warning(this.logStart + "Could not resolve VBR Console install directory from registry.");
+            return null;
         }
 
         private void ParseVbrMajorVersion(string fullVersion)

--- a/vHC/HC_Reporting/Functions/Collection/DB/CRegReader.cs
+++ b/vHC/HC_Reporting/Functions/Collection/DB/CRegReader.cs
@@ -88,6 +88,7 @@ namespace VeeamHealthCheck.Functions.Collection.DB
                 if (!string.IsNullOrEmpty(coreVersion))
                 {
                     CGlobals.VBRFULLVERSION = coreVersion;
+                    CGlobals.VbrConsoleInstallDir = Path.GetDirectoryName(consoleInstallPath);
                     this.ParseVbrMajorVersion(CGlobals.VBRFULLVERSION);
                     return coreVersion;
                 }
@@ -121,6 +122,7 @@ namespace VeeamHealthCheck.Functions.Collection.DB
                     // FileInfo dllInfo = new FileInfo(path + "\\Packages\\VeeamDeploymentDll.dll");
                     var version = FileVersionInfo.GetVersionInfo(path + "\\Veeam.Backup.Core.dll");
                     CGlobals.VBRFULLVERSION = version.FileVersion;
+                    CGlobals.VbrConsoleInstallDir = path;
                     this.ParseVbrMajorVersion(CGlobals.VBRFULLVERSION);
                     return CGlobals.VBRFULLVERSION;
                 }

--- a/vHC/HC_Reporting/Functions/Collection/DB/CVbrConsolePathResolver.cs
+++ b/vHC/HC_Reporting/Functions/Collection/DB/CVbrConsolePathResolver.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+
+namespace VeeamHealthCheck.Functions.Collection.DB
+{
+    internal static class CVbrConsolePathResolver
+    {
+        public static string SiblingConsoleDir(string installPath)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/vHC/HC_Reporting/Functions/Collection/DB/CVbrConsolePathResolver.cs
+++ b/vHC/HC_Reporting/Functions/Collection/DB/CVbrConsolePathResolver.cs
@@ -1,14 +1,32 @@
 // Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
 // MIT License
-using System;
-
 namespace VeeamHealthCheck.Functions.Collection.DB
 {
+    /// <summary>
+    /// Derives the Console\ directory from a registry-sourced VBR install path (CorePath's Backup\
+    /// folder, or the Mount Service's own install folder) that points at a sibling component
+    /// directory rather than Console\ itself. Uses manual backslash parsing rather than
+    /// System.IO.Path, since these are always Windows-style paths even when this logic runs on the
+    /// Linux/macOS cross-platform test runners (mirrors TestMfa.ps1's Resolve-VeeamConsolePath).
+    /// </summary>
     internal static class CVbrConsolePathResolver
     {
-        public static string SiblingConsoleDir(string installPath)
+        public static string? SiblingConsoleDir(string? installPath)
         {
-            throw new NotImplementedException();
+            if (string.IsNullOrEmpty(installPath))
+            {
+                return null;
+            }
+
+            string trimmed = installPath.TrimEnd('\\', '/');
+            int lastSeparator = trimmed.LastIndexOf('\\');
+            if (lastSeparator <= 0)
+            {
+                return null;
+            }
+
+            string parent = trimmed.Substring(0, lastSeparator);
+            return parent + "\\Console";
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Collection/DB/CVbrConsolePathResolver.cs
+++ b/vHC/HC_Reporting/Functions/Collection/DB/CVbrConsolePathResolver.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
 // MIT License
+#nullable enable
 namespace VeeamHealthCheck.Functions.Collection.DB
 {
     /// <summary>

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.Invocation.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.Invocation.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using System.Diagnostics;
+using VeeamHealthCheck.Functions.Collection;
+
+namespace VeeamHealthCheck.Functions.Collection.PSCollections
+{
+    /// <summary>
+    /// Process-invocation half of CPowerShellVersionChecker. Kept in a separate file (not linked
+    /// into the cross-platform test project) because it depends on CCollections, which pulls in a
+    /// WPF reference chain.
+    /// </summary>
+    internal static partial class CPowerShellVersionChecker
+    {
+        private const int VersionCheckTimeoutSeconds = 30;
+
+        /// <summary>
+        /// Invokes pwsh.exe to read $PSVersionTable.PSVersion. Returns false if pwsh cannot be
+        /// located, fails to exit within the timeout, or its output cannot be parsed.
+        /// </summary>
+        public static bool TryGetInstalledPwshVersion(out Version installedVersion, out string rawVersion)
+        {
+            installedVersion = null;
+            rawVersion = null;
+
+            string pwshPath = FindPwshExecutable();
+            if (string.IsNullOrEmpty(pwshPath))
+            {
+                return false;
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = pwshPath,
+                Arguments = "-NoProfile -Command \"$PSVersionTable.PSVersion.ToString()\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            try
+            {
+                // Async reads of both streams under a bounded timeout, same as the fix applied to
+                // PSInvoker for issue #149 - a synchronous ReadToEnd()/WaitForExit() here can
+                // deadlock if pwsh writes enough to stderr to fill the OS pipe buffer before exiting.
+                bool exited = CCollections.RunBoundedPowerShell(
+                    psi, VersionCheckTimeoutSeconds, "[PwshVersionCheck]",
+                    out string stdOut, out _, out _, out bool timedOut);
+
+                if (!exited || timedOut)
+                {
+                    return false;
+                }
+
+                return TryParsePwshVersionOutput(stdOut, out installedVersion, out rawVersion);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
 // MIT License
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -11,11 +10,17 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
     /// Determines whether the PowerShell 7 install on this machine meets the minimum version
     /// required by the installed Veeam.Backup.PowerShell module, so callers can fail fast with an
     /// actionable message instead of letting Import-Module abort deep inside a collection script.
+    /// Split into a partial class: this file holds the pure parsing/derivation logic (no WPF or
+    /// process-invocation dependency, so it can be linked into the cross-platform test project);
+    /// CPowerShellVersionChecker.Invocation.cs holds the process-invocation half.
     /// </summary>
-    internal static class CPowerShellVersionChecker
+    internal static partial class CPowerShellVersionChecker
     {
         private static readonly Regex ManifestVersionRegex =
             new(@"PowerShellVersion\s*=\s*['""]([\d.]+)['""]", RegexOptions.IgnoreCase);
+
+        private static readonly Regex AnsiEscapeRegex =
+            new(@"\x1B\[[0-?]*[ -/]*[@-~]", RegexOptions.Compiled);
 
         /// <summary>
         /// Reads the required "PowerShellVersion" entry from a PowerShell module manifest (.psd1).
@@ -51,61 +56,59 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
                 return false;
             }
 
-            Match match = ManifestVersionRegex.Match(manifestContent);
-            return match.Success && Version.TryParse(match.Groups[1].Value, out requiredVersion);
-        }
-
-        /// <summary>
-        /// Invokes pwsh.exe to read $PSVersionTable.PSVersion. Returns false if pwsh cannot be
-        /// located or its output cannot be parsed.
-        /// </summary>
-        public static bool TryGetInstalledPwshVersion(out Version installedVersion, out string rawVersion)
-        {
-            installedVersion = null;
-            rawVersion = null;
-
-            string pwshPath = FindPwshExecutable();
-            if (string.IsNullOrEmpty(pwshPath))
+            // Skip whole-line comments so a stale commented-out entry (e.g. left behind after a
+            // manual edit) can never win over the live one below it.
+            foreach (string line in manifestContent.Split('\n'))
             {
-                return false;
-            }
-
-            try
-            {
-                var psi = new ProcessStartInfo
+                if (line.TrimStart().StartsWith("#", StringComparison.Ordinal))
                 {
-                    FileName = pwshPath,
-                    Arguments = "-NoProfile -Command \"$PSVersionTable.PSVersion.ToString()\"",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
+                    continue;
+                }
 
-                using var process = Process.Start(psi);
-                string output = process.StandardOutput.ReadToEnd();
-                process.WaitForExit();
+                Match match = ManifestVersionRegex.Match(line);
+                if (match.Success && Version.TryParse(match.Groups[1].Value, out requiredVersion))
+                {
+                    return true;
+                }
+            }
 
-                return TryParsePwshVersionOutput(output, out installedVersion, out rawVersion);
-            }
-            catch
-            {
-                return false;
-            }
+            return false;
         }
 
         internal static bool TryParsePwshVersionOutput(string rawOutput, out Version installedVersion, out string rawVersion)
         {
             installedVersion = null;
-            rawVersion = rawOutput?.Trim();
+            rawVersion = null;
 
-            if (string.IsNullOrWhiteSpace(rawVersion))
+            if (string.IsNullOrWhiteSpace(rawOutput))
             {
                 return false;
             }
 
+            // Strip ANSI/SGR codes pwsh may emit on stdout (RunBoundedPowerShell only strips
+            // stderr) and take the last non-blank line, since $PSVersionTable.PSVersion.ToString()'s
+            // result is always printed last - any warning/notice text goes on earlier lines.
+            string cleaned = AnsiEscapeRegex.Replace(rawOutput, string.Empty);
+
+            string lastNonEmptyLine = null;
+            foreach (string line in cleaned.Split('\n'))
+            {
+                string trimmedLine = line.Trim();
+                if (!string.IsNullOrEmpty(trimmedLine))
+                {
+                    lastNonEmptyLine = trimmedLine;
+                }
+            }
+
+            if (string.IsNullOrEmpty(lastNonEmptyLine))
+            {
+                return false;
+            }
+
+            rawVersion = lastNonEmptyLine;
+
             // Strip prerelease/build metadata, e.g. "7.6.0-preview.3" -> "7.6.0"
-            string numericPart = rawVersion.Split('-')[0].Trim();
+            string numericPart = lastNonEmptyLine.Split('-')[0].Trim();
 
             return Version.TryParse(numericPart, out installedVersion);
         }

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
@@ -1,0 +1,139 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace VeeamHealthCheck.Functions.Collection.PSCollections
+{
+    /// <summary>
+    /// Determines whether the PowerShell 7 install on this machine meets the minimum version
+    /// required by the installed Veeam.Backup.PowerShell module, so callers can fail fast with an
+    /// actionable message instead of letting Import-Module abort deep inside a collection script.
+    /// </summary>
+    internal static class CPowerShellVersionChecker
+    {
+        private static readonly Regex ManifestVersionRegex =
+            new(@"PowerShellVersion\s*=\s*['""]([\d.]+)['""]", RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// Reads the required "PowerShellVersion" entry from a PowerShell module manifest (.psd1).
+        /// Returns false (with requiredVersion null) if the file is missing or unparsable so callers
+        /// can skip the preflight check rather than block a run over a manifest format they don't recognize.
+        /// </summary>
+        public static bool TryGetManifestRequiredVersion(string manifestPath, out Version requiredVersion)
+        {
+            requiredVersion = null;
+
+            if (string.IsNullOrEmpty(manifestPath) || !File.Exists(manifestPath))
+            {
+                return false;
+            }
+
+            try
+            {
+                string content = File.ReadAllText(manifestPath);
+                return TryParseManifestContent(content, out requiredVersion);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        internal static bool TryParseManifestContent(string manifestContent, out Version requiredVersion)
+        {
+            requiredVersion = null;
+
+            if (string.IsNullOrEmpty(manifestContent))
+            {
+                return false;
+            }
+
+            Match match = ManifestVersionRegex.Match(manifestContent);
+            return match.Success && Version.TryParse(match.Groups[1].Value, out requiredVersion);
+        }
+
+        /// <summary>
+        /// Invokes pwsh.exe to read $PSVersionTable.PSVersion. Returns false if pwsh cannot be
+        /// located or its output cannot be parsed.
+        /// </summary>
+        public static bool TryGetInstalledPwshVersion(out Version installedVersion, out string rawVersion)
+        {
+            installedVersion = null;
+            rawVersion = null;
+
+            string pwshPath = FindPwshExecutable();
+            if (string.IsNullOrEmpty(pwshPath))
+            {
+                return false;
+            }
+
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = pwshPath,
+                    Arguments = "-NoProfile -Command \"$PSVersionTable.PSVersion.ToString()\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(psi);
+                string output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit();
+
+                return TryParsePwshVersionOutput(output, out installedVersion, out rawVersion);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        internal static bool TryParsePwshVersionOutput(string rawOutput, out Version installedVersion, out string rawVersion)
+        {
+            installedVersion = null;
+            rawVersion = rawOutput?.Trim();
+
+            if (string.IsNullOrWhiteSpace(rawVersion))
+            {
+                return false;
+            }
+
+            // Strip prerelease/build metadata, e.g. "7.6.0-preview.3" -> "7.6.0"
+            string numericPart = rawVersion.Split('-')[0].Trim();
+
+            return Version.TryParse(numericPart, out installedVersion);
+        }
+
+        private static string FindPwshExecutable()
+        {
+            string pathEnv = Environment.GetEnvironmentVariable("PATH");
+            if (!string.IsNullOrEmpty(pathEnv))
+            {
+                foreach (string dir in pathEnv.Split(Path.PathSeparator))
+                {
+                    try
+                    {
+                        string candidate = Path.Combine(dir.Trim(), "pwsh.exe");
+                        if (File.Exists(candidate))
+                        {
+                            return candidate;
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore malformed PATH segments
+                    }
+                }
+            }
+
+            const string defaultPath = @"C:\Program Files\PowerShell\7\pwsh.exe";
+            return File.Exists(defaultPath) ? defaultPath : null;
+        }
+    }
+}

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
 // MIT License
+#nullable enable
 using System;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -27,7 +28,7 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
         /// Returns false (with requiredVersion null) if the file is missing or unparsable so callers
         /// can skip the preflight check rather than block a run over a manifest format they don't recognize.
         /// </summary>
-        public static bool TryGetManifestRequiredVersion(string manifestPath, out Version requiredVersion)
+        public static bool TryGetManifestRequiredVersion(string manifestPath, out Version? requiredVersion)
         {
             requiredVersion = null;
 
@@ -47,7 +48,7 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             }
         }
 
-        internal static bool TryParseManifestContent(string manifestContent, out Version requiredVersion)
+        internal static bool TryParseManifestContent(string manifestContent, out Version? requiredVersion)
         {
             requiredVersion = null;
 
@@ -75,7 +76,7 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             return false;
         }
 
-        internal static bool TryParsePwshVersionOutput(string rawOutput, out Version installedVersion, out string rawVersion)
+        internal static bool TryParsePwshVersionOutput(string rawOutput, out Version? installedVersion, out string? rawVersion)
         {
             installedVersion = null;
             rawVersion = null;
@@ -90,7 +91,7 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             // result is always printed last - any warning/notice text goes on earlier lines.
             string cleaned = AnsiEscapeRegex.Replace(rawOutput, string.Empty);
 
-            string lastNonEmptyLine = null;
+            string? lastNonEmptyLine = null;
             foreach (string line in cleaned.Split('\n'))
             {
                 string trimmedLine = line.Trim();
@@ -113,9 +114,9 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             return Version.TryParse(numericPart, out installedVersion);
         }
 
-        private static string FindPwshExecutable()
+        private static string? FindPwshExecutable()
         {
-            string pathEnv = Environment.GetEnvironmentVariable("PATH");
+            string? pathEnv = Environment.GetEnvironmentVariable("PATH");
             if (!string.IsNullOrEmpty(pathEnv))
             {
                 foreach (string dir in pathEnv.Split(Path.PathSeparator))

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
@@ -91,11 +91,16 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
                 catch { }
             }
 
-            // Return default path if not found in PATH
+            // Fall back to the default install path if not found in PATH - but only if it
+            // actually exists. Returning it unconditionally made DetectPowerShellVersions()
+            // treat PowerShell 7 as always present, so ExecutePsScriptWithFailover's "try PS7,
+            // then PS5" loop always attempted a nonexistent path and failed outright instead of
+            // falling back to PS5 when pwsh isn't installed. Mirrors
+            // CPowerShellVersionChecker.FindPwshExecutable.
             if (exeName.Equals("pwsh.exe", StringComparison.OrdinalIgnoreCase))
             {
-
-                return @"C:\Program Files\PowerShell\7\pwsh.exe";
+                const string defaultPwshPath = @"C:\Program Files\PowerShell\7\pwsh.exe";
+                return File.Exists(defaultPwshPath) ? defaultPwshPath : null;
             }
 
 

--- a/vHC/HC_Reporting/Startup/CArgsParser.cs
+++ b/vHC/HC_Reporting/Startup/CArgsParser.cs
@@ -319,7 +319,9 @@ namespace VeeamHealthCheck.Startup
 
             // Now that arguments are parsed, detect VBR version
             // This must happen after parsing so REMOTEEXEC flag is properly set
-            try { this.functions.GetVbrVersion(); }
+            // Detection only here (no PS 7.6+ gate) - the gate only applies to paths that lead
+            // into actual PowerShell-module-based collection, not e.g. the hotfix detector.
+            try { this.functions.DetectVbrVersion(); }
             catch (Exception ex)
             {
                 CGlobals.Logger.Debug($"VBR version detection skipped: {ex.Message}");
@@ -344,6 +346,15 @@ namespace VeeamHealthCheck.Startup
                 this.LaunchUi(this.Handle(), false);
             else if (run)
             {
+                // Gate on the PS 7.6+ module requirement here, right before any path that leads
+                // into actual collection (import, remote, and local all reach FullRun below).
+                // VBR version detection already ran above, so VbrConsoleInstallDir is populated.
+                try { this.functions.GetVbrVersion(); }
+                catch (Exception ex)
+                {
+                    CGlobals.Logger.Debug($"PowerShell version gate skipped: {ex.Message}");
+                }
+
                 if (CGlobals.IMPORT)
                      result = this.FullRun(targetDir);
                 else if (CGlobals.REMOTEEXEC && CGlobals.REMOTEHOST == string.Empty)

--- a/vHC/HC_Reporting/Startup/CArgsParser.cs
+++ b/vHC/HC_Reporting/Startup/CArgsParser.cs
@@ -317,15 +317,10 @@ namespace VeeamHealthCheck.Startup
                 }
             }
 
-            // Now that arguments are parsed, detect VBR version
-            // This must happen after parsing so REMOTEEXEC flag is properly set
-            // Detection only here (no PS 7.6+ gate) - the gate only applies to paths that lead
-            // into actual PowerShell-module-based collection, not e.g. the hotfix detector.
-            try { this.functions.DetectVbrVersion(); }
-            catch (Exception ex)
-            {
-                CGlobals.Logger.Debug($"VBR version detection skipped: {ex.Message}");
-            }
+            // Now that arguments are parsed, detect VBR version - see
+            // DetectVbrVersionIfTargeted()'s doc comment for the full rationale.
+            // This must happen after parsing so REMOTEEXEC flag is properly set.
+            this.DetectVbrVersionIfTargeted();
 
             int result = 0;
             if (string.IsNullOrEmpty(CGlobals.REMOTEHOST))
@@ -649,6 +644,34 @@ namespace VeeamHealthCheck.Startup
             if (string.IsNullOrEmpty(parsedOutDir)) return;
             CGlobals.desiredPath = parsedOutDir;
             CGlobals.mainlog = new CLogger("HealthCheck");
+        }
+
+        /// <summary>
+        /// Detects the VBR version right after CLI argument parsing, for any run that might
+        /// touch VBR. Skipped only for an explicit /vb365-only target: DetectVbrVersion()
+        /// reads the LOCAL machine's VBR registry keys, which are legitimately absent on a
+        /// VB365-only server, and its failure branch logs 5 ERROR-level lines for a totally
+        /// expected condition. Checked against the explicit TargetProductType flag only (not
+        /// EffectiveIsVbr/IsVbr): ModeCheck(), which populates the auto-detected
+        /// IsVbr/IsVb365 flags, hasn't run yet at this point in the CLI flow (it runs later,
+        /// and only for a subset of dispatch branches), so an Auto-mode run's real product mix
+        /// is still unknown here and detection must still be attempted.
+        /// </summary>
+        internal void DetectVbrVersionIfTargeted()
+        {
+            if (CGlobals.TargetProductType == TargetProduct.Vb365)
+            {
+                return;
+            }
+
+            try
+            {
+                this.functions.DetectVbrVersion();
+            }
+            catch (Exception ex)
+            {
+                CGlobals.Logger.Debug($"VBR version detection skipped: {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/vHC/HC_Reporting/Startup/CArgsParser.cs
+++ b/vHC/HC_Reporting/Startup/CArgsParser.cs
@@ -346,15 +346,12 @@ namespace VeeamHealthCheck.Startup
                 this.LaunchUi(this.Handle(), false);
             else if (run)
             {
-                // Gate on the PS 7.6+ module requirement here, right before any path that leads
-                // into actual collection (import, remote, and local all reach FullRun below).
-                // VBR version detection already ran above, so VbrConsoleInstallDir is populated.
-                try { this.functions.GetVbrVersion(); }
-                catch (Exception ex)
-                {
-                    CGlobals.Logger.Debug($"PowerShell version gate skipped: {ex.Message}");
-                }
-
+                // The PS 7.6+ module gate is no longer called here. It's private on
+                // CClientFunctions and enforced exactly once, from StartCollections(), the single
+                // choke point every path below (import, remote, local) eventually reaches via
+                // FullRun -> CliRun -> StartPrimaryFunctions. Calling it here too used to run it
+                // unconditionally even for /import (which never reaches real collection) and
+                // spawn pwsh.exe a second time on the plain local /run path.
                 if (CGlobals.IMPORT)
                      result = this.FullRun(targetDir);
                 else if (CGlobals.REMOTEEXEC && CGlobals.REMOTEHOST == string.Empty)

--- a/vHC/HC_Reporting/Startup/CClientFunctions.cs
+++ b/vHC/HC_Reporting/Startup/CClientFunctions.cs
@@ -161,7 +161,8 @@ namespace VeeamHealthCheck.Startup
                 // PS5 for VBR 12-). ModeCheck() runs from the GUI constructor before the window
                 // is shown and doesn't itself lead into PowerShell-module-based collection, so it
                 // must use the ungated DetectVbrVersion, not GetVbrVersion - the PS 7.6+ module
-                // gate is enforced once, immediately before real collection, in StartCollections().
+                // gate is enforced once, immediately before real collection, in StartCollections()
+                // via RunVbrPreflightGateIfTargeted().
                 try { this.DetectVbrVersion(); }
                 catch (Exception ex)
                 {
@@ -320,21 +321,9 @@ namespace VeeamHealthCheck.Startup
         {
             if (!CGlobals.IMPORT)
             {
-                // Single authoritative PS 7.6+ module preflight gate, right before the two
-                // branches below that both lead into real PowerShell-module-based collection.
-                // Gated only on !IMPORT (matches this method's own existing guard) - never on
-                // REMOTEEXEC: per repo convention, a preflight on the local PowerShell/module
-                // install must run regardless of REMOTEEXEC, since it is never the remote
-                // machine's problem. GetVbrVersion -> DetectVbrVersion throws by design when
-                // local VBR detection fails (e.g. a remote-only client with no local console) -
-                // not fatal, the preflight just can't run. This never swallows a genuine
-                // too-old-PowerShell failure: that path terminates via Environment.Exit /
-                // SilentExit.ExitSilent, neither of which throws.
-                try { this.GetVbrVersion(); }
-                catch (Exception ex)
-                {
-                    this.LOG.Debug(this.logStart + $"PowerShell version gate skipped: {ex.Message}");
-                }
+                // Single authoritative PS 7.6+ module preflight gate - see
+                // RunVbrPreflightGateIfTargeted()'s doc comment for the full rationale.
+                this.RunVbrPreflightGateIfTargeted();
 
                 this.LOG.Info(this.logStart + "Init Collections", false);
 
@@ -491,13 +480,47 @@ namespace VeeamHealthCheck.Startup
         }
 
         /// <summary>
+        /// Single authoritative PS 7.6+ module preflight gate, run once from StartCollections()
+        /// right before the two branches that both lead into real PowerShell-module-based
+        /// collection. Gated on EffectiveIsVbr - not IMPORT, not REMOTEEXEC - because this
+        /// preflight (and the PowerShell-version check it wraps) is meaningless for a run that
+        /// doesn't target VBR: DetectVbrVersion() reads the LOCAL machine's VBR registry keys,
+        /// which are legitimately absent on a VB365-only server, and previously spammed 5
+        /// ERROR-level log lines for a totally expected condition on every single such run.
+        /// Still runs whenever the target includes VBR (TargetProductType Vbr/Both, or Auto with
+        /// local VBR actually detected) regardless of REMOTEEXEC: per repo convention, a preflight
+        /// on the local PowerShell/module install must run regardless of REMOTEEXEC, since it is
+        /// never the remote machine's problem. GetVbrVersion -> DetectVbrVersion throws by design
+        /// when local VBR detection fails - not fatal, the preflight just can't run. This never
+        /// swallows a genuine too-old-PowerShell failure: that path terminates via
+        /// Environment.Exit / SilentExit.ExitSilent, neither of which throws.
+        /// </summary>
+        internal void RunVbrPreflightGateIfTargeted()
+        {
+            if (!CGlobals.EffectiveIsVbr)
+            {
+                return;
+            }
+
+            try
+            {
+                this.GetVbrVersion();
+            }
+            catch (Exception ex)
+            {
+                this.LOG.Debug(this.logStart + $"PowerShell version gate skipped: {ex.Message}");
+            }
+        }
+
+        /// <summary>
         /// Detects the VBR version and required PowerShell version and gates on the PS 7.6+
-        /// module requirement. Private: StartCollections() is the only caller, since it's the
-        /// single choke point (from both the GUI Run button and every CLI run path) immediately
-        /// before real PowerShell-module-based collection begins. Every other caller (ModeCheck,
-        /// RunHotfixDetector, early CLI arg-parsing detection) must call the ungated
-        /// DetectVbrVersion instead, so a too-old-PowerShell machine doesn't hard-exit a feature
-        /// that never touches the Veeam.Backup.PowerShell module.
+        /// module requirement. Private: RunVbrPreflightGateIfTargeted() is the only caller,
+        /// since it's the single choke point (reached from StartCollections(), itself reached
+        /// from both the GUI Run button and every CLI run path) immediately before real
+        /// PowerShell-module-based collection begins, and only when EffectiveIsVbr is true.
+        /// Every other caller (ModeCheck, RunHotfixDetector, early CLI arg-parsing detection)
+        /// must call the ungated DetectVbrVersion instead, so a too-old-PowerShell machine
+        /// doesn't hard-exit a feature that never touches the Veeam.Backup.PowerShell module.
         /// </summary>
         private void GetVbrVersion()
         {

--- a/vHC/HC_Reporting/Startup/CClientFunctions.cs
+++ b/vHC/HC_Reporting/Startup/CClientFunctions.cs
@@ -223,7 +223,9 @@ namespace VeeamHealthCheck.Startup
         public void RunHotfixDetector(string path, string remoteServer)
         {
             this.LOG.Info(this.logStart + "Starting Hotfix Detector", false);
-            this.GetVbrVersion();
+            // Hotfix detection only needs the version number, not the PS 7.6+ module gate -
+            // it never touches Veeam.Backup.PowerShell.
+            this.DetectVbrVersion();
             if (!String.IsNullOrEmpty(path))
             {
                 if (!this.VerifyPath(path))
@@ -456,7 +458,20 @@ namespace VeeamHealthCheck.Startup
             return this.StartPrimaryFunctions();
         }
 
+        /// <summary>
+        /// Detects the VBR version and required PowerShell version and gates on the PS 7.6+
+        /// module requirement. Callers that don't lead into PowerShell-module-based collection
+        /// (e.g. RunHotfixDetector, which only needs the version number) should call
+        /// DetectVbrVersion directly instead, so a too-old-PowerShell machine doesn't hard-exit a
+        /// feature that never touches the Veeam.Backup.PowerShell module.
+        /// </summary>
         public void GetVbrVersion()
+        {
+            this.DetectVbrVersion();
+            this.ValidatePowerShellVersionMeetsVbrRequirement();
+        }
+
+        internal void DetectVbrVersion()
         {
             try
             {
@@ -475,8 +490,6 @@ namespace VeeamHealthCheck.Startup
                 this.LOG.Info(this.logStart + "VBR Version: " + version, false);
                 CGlobals.PowerShellVersion = CGlobals.VBRMAJORVERSION >= 13 ? 7 : 5;
                 this.LOG.Info(this.logStart + "Using PowerShell version: " + CGlobals.PowerShellVersion.ToString(), false);
-
-                this.ValidatePowerShellVersionMeetsVbrRequirement();
 
                 // If PowerShell 7 is required AND we're doing remote execution, ensure we have credentials available
                 // For local VBR (IsVbr=true, REMOTEEXEC=false), credentials are NOT required - Windows auth is used

--- a/vHC/HC_Reporting/Startup/CClientFunctions.cs
+++ b/vHC/HC_Reporting/Startup/CClientFunctions.cs
@@ -152,9 +152,20 @@ namespace VeeamHealthCheck.Startup
                     CGlobals.IsVbr = true;
                     CGlobals.IsVbrInstalled = true;
                     this.LOG.Info("VBR software detected", false);
+                }
+            }
 
-                    // Get VBR version to determine correct PowerShell version (PS7 for VBR 13+, PS5 for VBR 12-)
-                    this.GetVbrVersion();
+            if (CGlobals.IsVbr)
+            {
+                // Detect VBR version to determine correct PowerShell version (PS7 for VBR 13+,
+                // PS5 for VBR 12-). ModeCheck() runs from the GUI constructor before the window
+                // is shown and doesn't itself lead into PowerShell-module-based collection, so it
+                // must use the ungated DetectVbrVersion, not GetVbrVersion - the PS 7.6+ module
+                // gate is enforced once, immediately before real collection, in StartCollections().
+                try { this.DetectVbrVersion(); }
+                catch (Exception ex)
+                {
+                    this.LOG.Debug(this.logStart + $"VBR version detection skipped: {ex.Message}");
                 }
             }
 
@@ -224,8 +235,13 @@ namespace VeeamHealthCheck.Startup
         {
             this.LOG.Info(this.logStart + "Starting Hotfix Detector", false);
             // Hotfix detection only needs the version number, not the PS 7.6+ module gate -
-            // it never touches Veeam.Backup.PowerShell.
-            this.DetectVbrVersion();
+            // it never touches Veeam.Backup.PowerShell. DetectVbrVersion throws by design on
+            // failure (e.g. no local VBR console) - don't let that crash /hotfix uncaught.
+            try { this.DetectVbrVersion(); }
+            catch (Exception ex)
+            {
+                this.LOG.Debug(this.logStart + $"VBR version detection skipped: {ex.Message}");
+            }
             if (!String.IsNullOrEmpty(path))
             {
                 if (!this.VerifyPath(path))
@@ -304,6 +320,22 @@ namespace VeeamHealthCheck.Startup
         {
             if (!CGlobals.IMPORT)
             {
+                // Single authoritative PS 7.6+ module preflight gate, right before the two
+                // branches below that both lead into real PowerShell-module-based collection.
+                // Gated only on !IMPORT (matches this method's own existing guard) - never on
+                // REMOTEEXEC: per repo convention, a preflight on the local PowerShell/module
+                // install must run regardless of REMOTEEXEC, since it is never the remote
+                // machine's problem. GetVbrVersion -> DetectVbrVersion throws by design when
+                // local VBR detection fails (e.g. a remote-only client with no local console) -
+                // not fatal, the preflight just can't run. This never swallows a genuine
+                // too-old-PowerShell failure: that path terminates via Environment.Exit /
+                // SilentExit.ExitSilent, neither of which throws.
+                try { this.GetVbrVersion(); }
+                catch (Exception ex)
+                {
+                    this.LOG.Debug(this.logStart + $"PowerShell version gate skipped: {ex.Message}");
+                }
+
                 this.LOG.Info(this.logStart + "Init Collections", false);
 
                 if (CGlobals.REMOTEEXEC && CGlobals.RunSecReport)
@@ -460,12 +492,14 @@ namespace VeeamHealthCheck.Startup
 
         /// <summary>
         /// Detects the VBR version and required PowerShell version and gates on the PS 7.6+
-        /// module requirement. Callers that don't lead into PowerShell-module-based collection
-        /// (e.g. RunHotfixDetector, which only needs the version number) should call
-        /// DetectVbrVersion directly instead, so a too-old-PowerShell machine doesn't hard-exit a
-        /// feature that never touches the Veeam.Backup.PowerShell module.
+        /// module requirement. Private: StartCollections() is the only caller, since it's the
+        /// single choke point (from both the GUI Run button and every CLI run path) immediately
+        /// before real PowerShell-module-based collection begins. Every other caller (ModeCheck,
+        /// RunHotfixDetector, early CLI arg-parsing detection) must call the ungated
+        /// DetectVbrVersion instead, so a too-old-PowerShell machine doesn't hard-exit a feature
+        /// that never touches the Veeam.Backup.PowerShell module.
         /// </summary>
-        public void GetVbrVersion()
+        private void GetVbrVersion()
         {
             this.DetectVbrVersion();
             this.ValidatePowerShellVersionMeetsVbrRequirement();
@@ -569,7 +603,22 @@ namespace VeeamHealthCheck.Startup
 
             if (CGlobals.GUIEXEC)
             {
-                MessageBox.Show(msg, "Unsupported PowerShell Version", MessageBoxButton.OK, MessageBoxImage.Error);
+                // Dispatch to the UI thread so the box is owned by the main window instead of
+                // desktop-parented - this can run from a background Task (StartCollections is
+                // invoked from VhcGui.Run()'s Task.Factory.StartNew), matching the existing
+                // convention in VhcGui.xaml.cs's ShowCollectionWarningsIfAny. Fall back to an
+                // undocked MessageBox.Show if there's no Dispatcher to marshal to - the user must
+                // still see this message before the Environment.Exit below, never silently.
+                System.Windows.Threading.Dispatcher dispatcher = Application.Current?.Dispatcher;
+                if (dispatcher != null)
+                {
+                    dispatcher.Invoke(() =>
+                        MessageBox.Show(msg, "Unsupported PowerShell Version", MessageBoxButton.OK, MessageBoxImage.Error));
+                }
+                else
+                {
+                    MessageBox.Show(msg, "Unsupported PowerShell Version", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
             }
 
             Environment.Exit(SilentExit.PowerShellVersionUnsupported);

--- a/vHC/HC_Reporting/Startup/CClientFunctions.cs
+++ b/vHC/HC_Reporting/Startup/CClientFunctions.cs
@@ -235,13 +235,22 @@ namespace VeeamHealthCheck.Startup
         public void RunHotfixDetector(string path, string remoteServer)
         {
             this.LOG.Info(this.logStart + "Starting Hotfix Detector", false);
-            // Hotfix detection only needs the version number, not the PS 7.6+ module gate -
-            // it never touches Veeam.Backup.PowerShell. DetectVbrVersion throws by design on
+            // Hotfix detection only needs the version number, not the PS 7.6+ module gate - it
+            // never touches Veeam.Backup.PowerShell. DetectVbrVersion throws by design on
             // failure (e.g. no local VBR console) - don't let that crash /hotfix uncaught.
-            try { this.DetectVbrVersion(); }
-            catch (Exception ex)
+            // Skipped only for an explicit /vb365-only target - EffectiveIsVbr/IsVbr can't be
+            // used here either: ModeCheck() never runs at all on the /hotfix dispatch branch,
+            // so the auto-detected IsVbr/IsVb365 flags are never populated for this call path.
+            if (CGlobals.TargetProductType != TargetProduct.Vb365)
             {
-                this.LOG.Debug(this.logStart + $"VBR version detection skipped: {ex.Message}");
+                try
+                {
+                    this.DetectVbrVersion();
+                }
+                catch (Exception ex)
+                {
+                    this.LOG.Debug(this.logStart + $"VBR version detection skipped: {ex.Message}");
+                }
             }
             if (!String.IsNullOrEmpty(path))
             {

--- a/vHC/HC_Reporting/Startup/CClientFunctions.cs
+++ b/vHC/HC_Reporting/Startup/CClientFunctions.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using VeeamHealthCheck.Functions.Collection;
 using VeeamHealthCheck.Functions.Collection.DB;
+using VeeamHealthCheck.Functions.Collection.PSCollections;
 using VeeamHealthCheck.Functions.CredsWindow;
 using VeeamHealthCheck.Resources.Localization;
 using VeeamHealthCheck.Shared;
@@ -475,6 +476,8 @@ namespace VeeamHealthCheck.Startup
                 CGlobals.PowerShellVersion = CGlobals.VBRMAJORVERSION >= 13 ? 7 : 5;
                 this.LOG.Info(this.logStart + "Using PowerShell version: " + CGlobals.PowerShellVersion.ToString(), false);
 
+                this.ValidatePowerShellVersionMeetsVbrRequirement();
+
                 // If PowerShell 7 is required AND we're doing remote execution, ensure we have credentials available
                 // For local VBR (IsVbr=true, REMOTEEXEC=false), credentials are NOT required - Windows auth is used
                 if (CGlobals.PowerShellVersion == 7 && CGlobals.REMOTEEXEC)
@@ -494,6 +497,69 @@ namespace VeeamHealthCheck.Startup
                 this.LOG.Error(this.logStart + "Stack trace: " + ex.StackTrace, false);
                 throw; // Re-throw to fail fast rather than continue with wrong PowerShell version
             }
+        }
+
+        /// <summary>
+        /// Preflight check for VBR 13+: compares the installed PowerShell 7 version against the
+        /// minimum required by the local Veeam.Backup.PowerShell module manifest, and exits with an
+        /// actionable message if it's too old. Without this, an under-versioned PowerShell only fails
+        /// later, deep inside a collection script's Import-Module call, with a confusing error trail
+        /// (see issue: VBR 13.1 requires PowerShell 7.6, but a 7.4.x install produces cascading
+        /// Get-Package / Import-Module / Connect-VBRServer errors instead of a clear message).
+        /// Reads the requirement from the manifest rather than hardcoding it, since Veeam can raise
+        /// the minimum again in a future VBR release. Skips (does not block the run) if the manifest
+        /// or installed pwsh version can't be determined - this is a best-effort UX improvement, not
+        /// a hard gate.
+        /// </summary>
+        private void ValidatePowerShellVersionMeetsVbrRequirement()
+        {
+            if (CGlobals.PowerShellVersion != 7)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(CGlobals.VbrConsoleInstallDir))
+            {
+                this.LOG.Debug(this.logStart + "VBR console install directory unknown. Skipping PowerShell module version preflight check.");
+                return;
+            }
+
+            string manifestPath = Path.Combine(CGlobals.VbrConsoleInstallDir, "Veeam.Backup.PowerShell", "Veeam.Backup.PowerShell.psd1");
+
+            if (!CPowerShellVersionChecker.TryGetManifestRequiredVersion(manifestPath, out Version requiredVersion))
+            {
+                this.LOG.Debug(this.logStart + $"Could not read required PowerShell version from '{manifestPath}'. Skipping preflight check.");
+                return;
+            }
+
+            if (!CPowerShellVersionChecker.TryGetInstalledPwshVersion(out Version installedVersion, out string rawInstalledVersion))
+            {
+                this.LOG.Debug(this.logStart + "Could not determine installed PowerShell 7 version. Skipping preflight check.");
+                return;
+            }
+
+            if (installedVersion >= requiredVersion)
+            {
+                return;
+            }
+
+            string msg = $"The Veeam Backup & Replication PowerShell module (VBR {CGlobals.VBRFULLVERSION}) requires PowerShell {requiredVersion} " +
+                         $"or higher, but this computer has PowerShell {rawInstalledVersion} installed. " +
+                         "Install a newer PowerShell 7 release (https://aka.ms/powershell-release?tag=stable) and re-run Veeam Health Check.";
+
+            this.LOG.Error(this.logStart + msg, false);
+
+            if (CGlobals.Silent)
+            {
+                SilentExit.ExitSilent(SilentExit.PowerShellVersionUnsupported, msg);
+            }
+
+            if (CGlobals.GUIEXEC)
+            {
+                MessageBox.Show(msg, "Unsupported PowerShell Version", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            Environment.Exit(SilentExit.PowerShellVersionUnsupported);
         }
 
         private void EnsureCredentialsAvailable()

--- a/vHC/VhcXTests.CrossPlatform/CPowerShellVersionCheckerParsingTests.cs
+++ b/vHC/VhcXTests.CrossPlatform/CPowerShellVersionCheckerParsingTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using Xunit;
+using VeeamHealthCheck.Functions.Collection.PSCollections;
+
+namespace VhcXTests.CrossPlatform;
+
+public class CPowerShellVersionCheckerParsingTests
+{
+    private static readonly string Esc = ((char)0x1B).ToString();
+
+    [Fact]
+    public void TryParsePwshVersionOutput_AnsiWrappedOutput_ParsesVersion()
+    {
+        string ansiOutput = Esc + "[93m7.6.0" + Esc + "[0m";
+
+        bool success = CPowerShellVersionChecker.TryParsePwshVersionOutput(ansiOutput, out Version? installed, out string? raw);
+
+        Assert.True(success);
+        Assert.Equal(Version.Parse("7.6.0"), installed);
+        Assert.Equal("7.6.0", raw);
+    }
+
+    [Fact]
+    public void TryParsePwshVersionOutput_NoiseLineBeforeVersion_ParsesLastLine()
+    {
+        bool success = CPowerShellVersionChecker.TryParsePwshVersionOutput("Update available: 7.6.1\n7.4.6", out Version? installed, out string? raw);
+
+        Assert.True(success);
+        Assert.Equal(Version.Parse("7.4.6"), installed);
+        Assert.Equal("7.4.6", raw);
+    }
+
+    [Fact]
+    public void TryParseManifestContent_CommentedOutEntryPrecedingLiveEntry_ParsesLiveEntry()
+    {
+        bool success = CPowerShellVersionChecker.TryParseManifestContent(
+            "# PowerShellVersion = '5.1'\nPowerShellVersion = '7.6'",
+            out Version? required);
+
+        Assert.True(success);
+        Assert.Equal(Version.Parse("7.6"), required);
+    }
+
+    [Fact]
+    public void TryParseManifestContent_EntirelyCommentedOutEntry_ReturnsFalse()
+    {
+        bool success = CPowerShellVersionChecker.TryParseManifestContent("# PowerShellVersion = '5.1'", out Version? required);
+
+        Assert.False(success);
+        Assert.Null(required);
+    }
+}

--- a/vHC/VhcXTests.CrossPlatform/CVbrConsolePathResolverTests.cs
+++ b/vHC/VhcXTests.CrossPlatform/CVbrConsolePathResolverTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using Xunit;
+using VeeamHealthCheck.Functions.Collection.DB;
+
+namespace VhcXTests.CrossPlatform;
+
+public class CVbrConsolePathResolverTests
+{
+    [Fact]
+    public void SiblingConsoleDir_CorePathWithTrailingBackslash_ReturnsSiblingConsoleDirectory()
+    {
+        string result = CVbrConsolePathResolver.SiblingConsoleDir(@"D:\Program Files\Veeam\Backup and Replication\Backup\");
+
+        Assert.Equal(@"D:\Program Files\Veeam\Backup and Replication\Console", result);
+    }
+
+    [Fact]
+    public void SiblingConsoleDir_MountServicePathWithoutTrailingBackslash_ReturnsSiblingConsoleDirectory()
+    {
+        string result = CVbrConsolePathResolver.SiblingConsoleDir(@"C:\Program Files\Common Files\Veeam\Backup and Replication\Mount Service");
+
+        Assert.Equal(@"C:\Program Files\Common Files\Veeam\Backup and Replication\Console", result);
+    }
+
+    [Fact]
+    public void SiblingConsoleDir_NullPath_ReturnsNull()
+    {
+        string result = CVbrConsolePathResolver.SiblingConsoleDir(null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SiblingConsoleDir_EmptyPath_ReturnsNull()
+    {
+        string result = CVbrConsolePathResolver.SiblingConsoleDir(string.Empty);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SiblingConsoleDir_DriveRootWithNoParent_ReturnsNull()
+    {
+        string result = CVbrConsolePathResolver.SiblingConsoleDir(@"D:\");
+
+        Assert.Null(result);
+    }
+}

--- a/vHC/VhcXTests.CrossPlatform/CVbrConsolePathResolverTests.cs
+++ b/vHC/VhcXTests.CrossPlatform/CVbrConsolePathResolverTests.cs
@@ -10,7 +10,7 @@ public class CVbrConsolePathResolverTests
     [Fact]
     public void SiblingConsoleDir_CorePathWithTrailingBackslash_ReturnsSiblingConsoleDirectory()
     {
-        string result = CVbrConsolePathResolver.SiblingConsoleDir(@"D:\Program Files\Veeam\Backup and Replication\Backup\");
+        string? result = CVbrConsolePathResolver.SiblingConsoleDir(@"D:\Program Files\Veeam\Backup and Replication\Backup\");
 
         Assert.Equal(@"D:\Program Files\Veeam\Backup and Replication\Console", result);
     }
@@ -18,7 +18,7 @@ public class CVbrConsolePathResolverTests
     [Fact]
     public void SiblingConsoleDir_MountServicePathWithoutTrailingBackslash_ReturnsSiblingConsoleDirectory()
     {
-        string result = CVbrConsolePathResolver.SiblingConsoleDir(@"C:\Program Files\Common Files\Veeam\Backup and Replication\Mount Service");
+        string? result = CVbrConsolePathResolver.SiblingConsoleDir(@"C:\Program Files\Common Files\Veeam\Backup and Replication\Mount Service");
 
         Assert.Equal(@"C:\Program Files\Common Files\Veeam\Backup and Replication\Console", result);
     }
@@ -26,7 +26,7 @@ public class CVbrConsolePathResolverTests
     [Fact]
     public void SiblingConsoleDir_NullPath_ReturnsNull()
     {
-        string result = CVbrConsolePathResolver.SiblingConsoleDir(null);
+        string? result = CVbrConsolePathResolver.SiblingConsoleDir(null);
 
         Assert.Null(result);
     }
@@ -34,7 +34,7 @@ public class CVbrConsolePathResolverTests
     [Fact]
     public void SiblingConsoleDir_EmptyPath_ReturnsNull()
     {
-        string result = CVbrConsolePathResolver.SiblingConsoleDir(string.Empty);
+        string? result = CVbrConsolePathResolver.SiblingConsoleDir(string.Empty);
 
         Assert.Null(result);
     }
@@ -42,7 +42,7 @@ public class CVbrConsolePathResolverTests
     [Fact]
     public void SiblingConsoleDir_DriveRootWithNoParent_ReturnsNull()
     {
-        string result = CVbrConsolePathResolver.SiblingConsoleDir(@"D:\");
+        string? result = CVbrConsolePathResolver.SiblingConsoleDir(@"D:\");
 
         Assert.Null(result);
     }

--- a/vHC/VhcXTests.CrossPlatform/VhcXTests.CrossPlatform.csproj
+++ b/vHC/VhcXTests.CrossPlatform/VhcXTests.CrossPlatform.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\HC_Reporting\Functions\Reporting\Html\Shared\CHtmlBuilder.cs" Link="CHtmlBuilder.cs" />
     <Compile Include="..\HC_Reporting\Functions\Reporting\Html\Shared\CSectionTable.cs" Link="CSectionTable.cs" />
     <Compile Include="..\HC_Reporting\Functions\Collection\DB\CVbrConsolePathResolver.cs" Link="CVbrConsolePathResolver.cs" />
+    <Compile Include="..\HC_Reporting\Functions\Collection\PSCollections\CPowerShellVersionChecker.cs" Link="CPowerShellVersionChecker.cs" />
   </ItemGroup>
 
 </Project>

--- a/vHC/VhcXTests.CrossPlatform/VhcXTests.CrossPlatform.csproj
+++ b/vHC/VhcXTests.CrossPlatform/VhcXTests.CrossPlatform.csproj
@@ -23,6 +23,7 @@
     <Compile Include="..\HC_Reporting\Startup\CHostNameHelper.cs" Link="CHostNameHelper.cs" />
     <Compile Include="..\HC_Reporting\Functions\Reporting\Html\Shared\CHtmlBuilder.cs" Link="CHtmlBuilder.cs" />
     <Compile Include="..\HC_Reporting\Functions\Reporting\Html\Shared\CSectionTable.cs" Link="CSectionTable.cs" />
+    <Compile Include="..\HC_Reporting\Functions\Collection\DB\CVbrConsolePathResolver.cs" Link="CVbrConsolePathResolver.cs" />
   </ItemGroup>
 
 </Project>

--- a/vHC/VhcXTests/CArgsParserTEST.cs
+++ b/vHC/VhcXTests/CArgsParserTEST.cs
@@ -11,8 +11,23 @@ using Xunit;
 namespace VhcXTests
 {
     [Collection("GlobalState")]
-    public class CArgsParserTests
+    public class CArgsParserTests : IDisposable
     {
+        private readonly TargetProduct _origTargetProductType;
+        private readonly int _origMajorVersion;
+
+        public CArgsParserTests()
+        {
+            _origTargetProductType = CGlobals.TargetProductType;
+            _origMajorVersion = CGlobals.VBRMAJORVERSION;
+        }
+
+        public void Dispose()
+        {
+            CGlobals.TargetProductType = _origTargetProductType;
+            CGlobals.VBRMAJORVERSION = _origMajorVersion;
+        }
+
         // Helper method to access private ParsePath method via reflection
         private string? InvokeParsePathMethod(CArgsParser parser, string input)
         {
@@ -825,5 +840,37 @@ namespace VhcXTests
         }
 
         #endregion
+
+        [Fact]
+        public void DetectVbrVersionIfTargeted_TargetProductVb365_SkipsVbrDetection()
+        {
+            CGlobals.TargetProductType = TargetProduct.Vb365;
+            CGlobals.VBRMAJORVERSION = -1;
+
+            var parser = new CArgsParser(new string[] { });
+
+            Exception? ex = Record.Exception(() => parser.DetectVbrVersionIfTargeted());
+
+            Assert.Null(ex);
+            Assert.Equal(-1, CGlobals.VBRMAJORVERSION);
+        }
+
+        [Fact]
+        public void DetectVbrVersionIfTargeted_TargetProductAuto_DoesNotThrow()
+        {
+            // Smoke test only: DetectVbrVersion() swallows its own exceptions internally, so
+            // this can't distinguish "Auto mode correctly still attempted detection" from "the
+            // gate was wrongly broadened to skip it" - both look identical here. The actual
+            // guard against over-broadening this to EffectiveIsVbr-style logic (which would
+            // incorrectly skip Auto-mode detection, since ModeCheck() hasn't run yet at this
+            // point in the CLI flow) is DetectVbrVersionIfTargeted()'s own doc comment.
+            CGlobals.TargetProductType = TargetProduct.Auto;
+
+            var parser = new CArgsParser(new string[] { });
+
+            Exception? ex = Record.Exception(() => parser.DetectVbrVersionIfTargeted());
+
+            Assert.Null(ex);
+        }
     }
 }

--- a/vHC/VhcXTests/CClientFunctionsGateTests.cs
+++ b/vHC/VhcXTests/CClientFunctionsGateTests.cs
@@ -10,11 +10,12 @@ namespace VhcXTests
 {
     /// <summary>
     /// Regression tests for the PS 7.6+ module preflight gate's call-site contract: GetVbrVersion
-    /// (gated: detect + hard-exit-if-too-old) must only ever be called from StartCollections, the
-    /// single choke point immediately before real PowerShell-module-based collection. Every other
-    /// caller (ModeCheck, RunHotfixDetector) must use the ungated DetectVbrVersion so a
-    /// too-old-PowerShell machine doesn't hard-exit a feature that never touches
-    /// Veeam.Backup.PowerShell.
+    /// (gated: detect + hard-exit-if-too-old) must only ever be called from
+    /// RunVbrPreflightGateIfTargeted(), reached from StartCollections() - the single choke point
+    /// immediately before real PowerShell-module-based collection, and only when
+    /// CGlobals.EffectiveIsVbr is true. Every other caller (ModeCheck, RunHotfixDetector) must use
+    /// the ungated DetectVbrVersion so a too-old-PowerShell machine doesn't hard-exit a feature
+    /// that never touches Veeam.Backup.PowerShell.
     ///
     /// Naming convention: [Method]_[Scenario]_[Expected].
     /// </summary>
@@ -27,6 +28,7 @@ namespace VhcXTests
         private readonly int _origPowerShellVersion;
         private readonly bool _origIsVbr;
         private readonly bool _origIsVb365;
+        private readonly TargetProduct _origTargetProductType;
 
         public CClientFunctionsGateTests()
         {
@@ -36,6 +38,7 @@ namespace VhcXTests
             _origPowerShellVersion = CGlobals.PowerShellVersion;
             _origIsVbr = CGlobals.IsVbr;
             _origIsVb365 = CGlobals.IsVb365;
+            _origTargetProductType = CGlobals.TargetProductType;
         }
 
         public void Dispose()
@@ -46,14 +49,15 @@ namespace VhcXTests
             CGlobals.PowerShellVersion = _origPowerShellVersion;
             CGlobals.IsVbr = _origIsVbr;
             CGlobals.IsVb365 = _origIsVb365;
+            CGlobals.TargetProductType = _origTargetProductType;
         }
 
         [Fact]
         public void GetVbrVersion_MethodVisibility_IsPrivate()
         {
             // Regression guard for the root cause of the ModeCheck() hard-exit-on-GUI-startup
-            // bug: GetVbrVersion must stay private so StartCollections() remains its only
-            // possible caller.
+            // bug: GetVbrVersion must stay private so RunVbrPreflightGateIfTargeted() remains
+            // its only possible caller.
             var method = typeof(CClientFunctions).GetMethod(
                 "GetVbrVersion", BindingFlags.NonPublic | BindingFlags.Instance);
 
@@ -68,8 +72,8 @@ namespace VhcXTests
             // leave VBRMAJORVERSION at 0 whether or not the !IMPORT guard actually skipped it, so
             // this can't distinguish "gate correctly skipped" from "gate ran and failed anyway".
             // The real regression guard for the gate's call-site contract is
-            // GetVbrVersion_MethodVisibility_IsPrivate below, which makes StartCollections() the
-            // only possible caller at compile time.
+            // GetVbrVersion_MethodVisibility_IsPrivate below, which makes
+            // RunVbrPreflightGateIfTargeted() the only possible caller at compile time.
             CGlobals.IMPORT = true;
 
             using var functions = new CClientFunctions();
@@ -118,6 +122,60 @@ namespace VhcXTests
             {
                 Assert.Equal("fail", result);
             }
+        }
+
+        [Fact]
+        public void RunVbrPreflightGateIfTargeted_TargetProductVb365_SkipsVbrDetection()
+        {
+            // Sentinel-only discriminator: on a machine with local VBR actually detectable,
+            // DetectVbrVersion() succeeding would overwrite VBRMAJORVERSION away from this
+            // sentinel, proving the gate ran; on a CI runner without VBR, the failure branch
+            // never touches VBRMAJORVERSION at all (CRegReader.GetVbrVersionFilePath only
+            // writes it on success), so this can't by itself distinguish "skipped" from "ran
+            // and failed" there. The real, machine-independent regression coverage of the
+            // underlying EffectiveIsVbr logic is EffectiveIsVbr_ForTargetProductAndIsVbr_
+            // ReturnsExpected below.
+            CGlobals.TargetProductType = TargetProduct.Vb365;
+            CGlobals.VBRMAJORVERSION = -1;
+
+            using var functions = new CClientFunctions();
+
+            Exception? ex = Record.Exception(() => functions.RunVbrPreflightGateIfTargeted());
+
+            Assert.Null(ex);
+            Assert.Equal(-1, CGlobals.VBRMAJORVERSION);
+        }
+
+        [Fact]
+        public void RunVbrPreflightGateIfTargeted_TargetProductAutoNoLocalVbr_SkipsVbrDetection()
+        {
+            // Realistic auto-detected VB365-only scenario from the bug report. Same
+            // machine-dependent discriminator limitation as the test above.
+            CGlobals.TargetProductType = TargetProduct.Auto;
+            CGlobals.IsVbr = false;
+            CGlobals.IsVb365 = true;
+            CGlobals.VBRMAJORVERSION = -1;
+
+            using var functions = new CClientFunctions();
+
+            Exception? ex = Record.Exception(() => functions.RunVbrPreflightGateIfTargeted());
+
+            Assert.Null(ex);
+            Assert.Equal(-1, CGlobals.VBRMAJORVERSION);
+        }
+
+        [Theory]
+        [InlineData(TargetProduct.Vbr, false, true)]
+        [InlineData(TargetProduct.Both, false, true)]
+        [InlineData(TargetProduct.Vb365, false, false)]
+        [InlineData(TargetProduct.Auto, false, false)]
+        [InlineData(TargetProduct.Auto, true, true)]
+        public void EffectiveIsVbr_ForTargetProductAndIsVbr_ReturnsExpected(TargetProduct targetProduct, bool isVbr, bool expected)
+        {
+            CGlobals.TargetProductType = targetProduct;
+            CGlobals.IsVbr = isVbr;
+
+            Assert.Equal(expected, CGlobals.EffectiveIsVbr);
         }
     }
 }

--- a/vHC/VhcXTests/CClientFunctionsGateTests.cs
+++ b/vHC/VhcXTests/CClientFunctionsGateTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using System.Reflection;
+using VeeamHealthCheck.Shared;
+using VeeamHealthCheck.Startup;
+using Xunit;
+
+namespace VhcXTests
+{
+    /// <summary>
+    /// Regression tests for the PS 7.6+ module preflight gate's call-site contract: GetVbrVersion
+    /// (gated: detect + hard-exit-if-too-old) must only ever be called from StartCollections, the
+    /// single choke point immediately before real PowerShell-module-based collection. Every other
+    /// caller (ModeCheck, RunHotfixDetector) must use the ungated DetectVbrVersion so a
+    /// too-old-PowerShell machine doesn't hard-exit a feature that never touches
+    /// Veeam.Backup.PowerShell.
+    ///
+    /// Naming convention: [Method]_[Scenario]_[Expected].
+    /// </summary>
+    [Collection("GlobalState")]
+    public class CClientFunctionsGateTests : IDisposable
+    {
+        private readonly bool _origImport;
+        private readonly int _origMajorVersion;
+        private readonly string _origConsoleInstallDir;
+        private readonly int _origPowerShellVersion;
+        private readonly bool _origIsVbr;
+        private readonly bool _origIsVb365;
+
+        public CClientFunctionsGateTests()
+        {
+            _origImport = CGlobals.IMPORT;
+            _origMajorVersion = CGlobals.VBRMAJORVERSION;
+            _origConsoleInstallDir = CGlobals.VbrConsoleInstallDir;
+            _origPowerShellVersion = CGlobals.PowerShellVersion;
+            _origIsVbr = CGlobals.IsVbr;
+            _origIsVb365 = CGlobals.IsVb365;
+        }
+
+        public void Dispose()
+        {
+            CGlobals.IMPORT = _origImport;
+            CGlobals.VBRMAJORVERSION = _origMajorVersion;
+            CGlobals.VbrConsoleInstallDir = _origConsoleInstallDir;
+            CGlobals.PowerShellVersion = _origPowerShellVersion;
+            CGlobals.IsVbr = _origIsVbr;
+            CGlobals.IsVb365 = _origIsVb365;
+        }
+
+        [Fact]
+        public void GetVbrVersion_MethodVisibility_IsPrivate()
+        {
+            // Regression guard for the root cause of the ModeCheck() hard-exit-on-GUI-startup
+            // bug: GetVbrVersion must stay private so StartCollections() remains its only
+            // possible caller.
+            var method = typeof(CClientFunctions).GetMethod(
+                "GetVbrVersion", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            Assert.NotNull(method);
+            Assert.True(method.IsPrivate);
+        }
+
+        [Fact]
+        public void StartCollections_ImportModeEnabled_DoesNotThrow()
+        {
+            // Smoke test only: on a CI runner without VBR installed, DetectVbrVersion() would
+            // leave VBRMAJORVERSION at 0 whether or not the !IMPORT guard actually skipped it, so
+            // this can't distinguish "gate correctly skipped" from "gate ran and failed anyway".
+            // The real regression guard for the gate's call-site contract is
+            // GetVbrVersion_MethodVisibility_IsPrivate below, which makes StartCollections() the
+            // only possible caller at compile time.
+            CGlobals.IMPORT = true;
+
+            using var functions = new CClientFunctions();
+            var method = typeof(CClientFunctions).GetMethod(
+                "StartCollections", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            Exception? ex = Record.Exception(() => method.Invoke(functions, Array.Empty<object>()));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void RunHotfixDetector_DetectVbrVersionThrows_DoesNotPropagate()
+        {
+            CGlobals.VBRMAJORVERSION = 0;
+            CGlobals.VbrConsoleInstallDir = null;
+
+            using var functions = new CClientFunctions();
+
+            // A UNC path is rejected by VerifyPath before CHotfixDetector ever runs, keeping this
+            // test focused on the DetectVbrVersion try/catch (added by this fix) rather than
+            // exercising the real hotfix-detection flow.
+            Exception? ex = Record.Exception(() => functions.RunHotfixDetector(@"\\invalid\nonexistent\path", string.Empty));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void ModeCheck_NoVeeamProcessRunning_ReturnsFailWithoutThrowing()
+        {
+            CGlobals.IsVbr = false;
+            CGlobals.IsVb365 = false;
+
+            using var functions = new CClientFunctions();
+
+            string? result = null;
+            Exception? ex = Record.Exception(() => { result = functions.ModeCheck(); });
+
+            Assert.Null(ex);
+
+            // Only meaningful when no Veeam.Backup.Service/Veeam.Archiver.Service process is
+            // actually running on the test machine (true for standard CI runners) - otherwise
+            // ModeCheck() legitimately won't return "fail".
+            if (!CGlobals.IsVbr && !CGlobals.IsVb365)
+            {
+                Assert.Equal("fail", result);
+            }
+        }
+    }
+}

--- a/vHC/VhcXTests/CClientFunctionsGateTests.cs
+++ b/vHC/VhcXTests/CClientFunctionsGateTests.cs
@@ -89,6 +89,10 @@ namespace VhcXTests
         [Fact]
         public void RunHotfixDetector_DetectVbrVersionThrows_DoesNotPropagate()
         {
+            // Pinned to Auto (not Vb365) so the new TargetProductType gate doesn't skip
+            // DetectVbrVersion() entirely and make this test vacuously pass regardless of
+            // whatever TargetProductType a prior test in this shared collection left behind.
+            CGlobals.TargetProductType = TargetProduct.Auto;
             CGlobals.VBRMAJORVERSION = 0;
             CGlobals.VbrConsoleInstallDir = null;
 
@@ -100,6 +104,23 @@ namespace VhcXTests
             Exception? ex = Record.Exception(() => functions.RunHotfixDetector(@"\\invalid\nonexistent\path", string.Empty));
 
             Assert.Null(ex);
+        }
+
+        [Fact]
+        public void RunHotfixDetector_TargetProductVb365_SkipsVbrDetection()
+        {
+            // Same invalid-UNC-path technique as RunHotfixDetector_DetectVbrVersionThrows_
+            // DoesNotPropagate above: VerifyPath rejects it before CHotfixDetector ever runs,
+            // isolating this test to just the new TargetProductType gate.
+            CGlobals.TargetProductType = TargetProduct.Vb365;
+            CGlobals.VBRMAJORVERSION = -1;
+
+            using var functions = new CClientFunctions();
+
+            Exception? ex = Record.Exception(() => functions.RunHotfixDetector(@"\\invalid\nonexistent\path", string.Empty));
+
+            Assert.Null(ex);
+            Assert.Equal(-1, CGlobals.VBRMAJORVERSION);
         }
 
         [Fact]

--- a/vHC/VhcXTests/CRegReaderTests.cs
+++ b/vHC/VhcXTests/CRegReaderTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System.IO;
+using Microsoft.Win32;
+using VeeamHealthCheck.Functions.Collection.DB;
+using Xunit;
+
+namespace VhcXTests
+{
+    /// <summary>
+    /// Regression tests for GetVbrVersionFilePath's Mount Service fallback branch, which
+    /// previously risked an uncaught NullReferenceException (missing registry key) or
+    /// FileNotFoundException (stale InstallationPath value pointing at a missing DLL) instead of
+    /// degrading to a clean null return.
+    ///
+    /// Naming convention: [Method]_[Scenario]_[Expected].
+    /// </summary>
+    [Collection("GlobalState")]
+    public class CRegReaderTests
+    {
+        private const string DefaultConsolePath =
+            @"C:\Program Files\Veeam\Backup and Replication\Console\Veeam.Backup.Core.dll";
+
+        [Fact]
+        public void GetVbrVersionFilePath_NoLocalConsoleAndNoMountServiceKey_ReturnsNullInsteadOfThrowing()
+        {
+            // This regression guard only applies on a machine without VBR/Mount Service
+            // installed (true for standard CI runners). If either is present, there's nothing to
+            // regression-test here - skip rather than assert against environment-dependent state.
+            bool mountServiceKeyExists;
+            using (RegistryKey key = Registry.LocalMachine.OpenSubKey("Software\\Veeam\\Veeam Mount Service"))
+            {
+                mountServiceKeyExists = key != null;
+            }
+
+            if (File.Exists(DefaultConsolePath) || mountServiceKeyExists)
+            {
+                return;
+            }
+
+            var reg = new CRegReader();
+
+            string result = reg.GetVbrVersionFilePath();
+
+            Assert.Null(result);
+        }
+    }
+}

--- a/vHC/VhcXTests/Functions/Collection/PSCollections/CPowerShellVersionCheckerTests.cs
+++ b/vHC/VhcXTests/Functions/Collection/PSCollections/CPowerShellVersionCheckerTests.cs
@@ -64,7 +64,7 @@ namespace VeeamHealthCheck.Tests.Functions.Collection.PSCollections
         }
 
         [Fact]
-        public void VersionComparison_BelowRequirement_IsDetected()
+        public void TryParsePwshVersionOutput_VersionBelowManifestRequirement_ComparesAsLower()
         {
             CPowerShellVersionChecker.TryParsePwshVersionOutput("7.4.6", out Version installed, out _);
             CPowerShellVersionChecker.TryParseManifestContent("PowerShellVersion = '7.6'", out Version required);
@@ -76,7 +76,7 @@ namespace VeeamHealthCheck.Tests.Functions.Collection.PSCollections
         [InlineData("7.6.0")]
         [InlineData("7.6.1")]
         [InlineData("8.0.0")]
-        public void VersionComparison_MeetsOrExceedsRequirement_IsNotBelowRequirement(string installedRaw)
+        public void TryParsePwshVersionOutput_VersionMeetsOrExceedsManifestRequirement_DoesNotCompareAsLower(string installedRaw)
         {
             CPowerShellVersionChecker.TryParsePwshVersionOutput(installedRaw, out Version installed, out _);
             CPowerShellVersionChecker.TryParseManifestContent("PowerShellVersion = '7.6'", out Version required);

--- a/vHC/VhcXTests/Functions/Collection/PSCollections/CPowerShellVersionCheckerTests.cs
+++ b/vHC/VhcXTests/Functions/Collection/PSCollections/CPowerShellVersionCheckerTests.cs
@@ -1,0 +1,87 @@
+// <copyright file="CPowerShellVersionCheckerTests.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using System;
+using VeeamHealthCheck.Functions.Collection.PSCollections;
+using Xunit;
+
+namespace VeeamHealthCheck.Tests.Functions.Collection.PSCollections
+{
+    public class CPowerShellVersionCheckerTests
+    {
+        [Theory]
+        [InlineData("PowerShellVersion = '7.6'", "7.6")]
+        [InlineData("PowerShellVersion = \"7.6\"", "7.6")]
+        [InlineData("PowerShellVersion   =   '7.5.1'", "7.5.1")]
+        [InlineData("@{\n  RootModule = 'Veeam.Backup.PowerShell.dll'\n  PowerShellVersion = '7.6'\n  Author = 'Veeam'\n}", "7.6")]
+        public void TryParseManifestContent_ValidPowerShellVersionEntry_ParsesVersion(string manifest, string expected)
+        {
+            bool success = CPowerShellVersionChecker.TryParseManifestContent(manifest, out Version result);
+
+            Assert.True(success);
+            Assert.Equal(Version.Parse(expected), result);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("@{ RootModule = 'Veeam.Backup.PowerShell.dll' }")]
+        [InlineData("PowerShellVersion = ''")]
+        public void TryParseManifestContent_MissingOrUnparsableEntry_ReturnsFalse(string manifest)
+        {
+            bool success = CPowerShellVersionChecker.TryParseManifestContent(manifest, out Version result);
+
+            Assert.False(success);
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("7.4.6", "7.4.6")]
+        [InlineData("7.6.0\n", "7.6.0")]
+        [InlineData("  7.6.0  ", "7.6.0")]
+        [InlineData("7.6.0-preview.3", "7.6.0")]
+        public void TryParsePwshVersionOutput_ValidOutput_ParsesVersion(string rawOutput, string expectedVersion)
+        {
+            bool success = CPowerShellVersionChecker.TryParsePwshVersionOutput(rawOutput, out Version installed, out string raw);
+
+            Assert.True(success);
+            Assert.Equal(Version.Parse(expectedVersion), installed);
+            Assert.Equal(rawOutput.Trim(), raw);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("   ")]
+        [InlineData("not-a-version")]
+        public void TryParsePwshVersionOutput_EmptyOrUnparsableOutput_ReturnsFalse(string rawOutput)
+        {
+            bool success = CPowerShellVersionChecker.TryParsePwshVersionOutput(rawOutput, out Version installed, out _);
+
+            Assert.False(success);
+            Assert.Null(installed);
+        }
+
+        [Fact]
+        public void VersionComparison_BelowRequirement_IsDetected()
+        {
+            CPowerShellVersionChecker.TryParsePwshVersionOutput("7.4.6", out Version installed, out _);
+            CPowerShellVersionChecker.TryParseManifestContent("PowerShellVersion = '7.6'", out Version required);
+
+            Assert.True(installed < required);
+        }
+
+        [Theory]
+        [InlineData("7.6.0")]
+        [InlineData("7.6.1")]
+        [InlineData("8.0.0")]
+        public void VersionComparison_MeetsOrExceedsRequirement_IsNotBelowRequirement(string installedRaw)
+        {
+            CPowerShellVersionChecker.TryParsePwshVersionOutput(installedRaw, out Version installed, out _);
+            CPowerShellVersionChecker.TryParseManifestContent("PowerShellVersion = '7.6'", out Version required);
+
+            Assert.False(installed < required);
+        }
+    }
+}

--- a/vHC/VhcXTests/Functions/Collection/PSCollections/CPowerShellVersionCheckerTests.cs
+++ b/vHC/VhcXTests/Functions/Collection/PSCollections/CPowerShellVersionCheckerTests.cs
@@ -83,5 +83,47 @@ namespace VeeamHealthCheck.Tests.Functions.Collection.PSCollections
 
             Assert.False(installed < required);
         }
+
+        [Fact]
+        public void TryParsePwshVersionOutput_AnsiWrappedOutput_ParsesVersion()
+        {
+            string ansiOutput = ((char)0x1B) + "[93m7.6.0" + ((char)0x1B) + "[0m";
+
+            bool success = CPowerShellVersionChecker.TryParsePwshVersionOutput(ansiOutput, out Version installed, out string raw);
+
+            Assert.True(success);
+            Assert.Equal(Version.Parse("7.6.0"), installed);
+            Assert.Equal("7.6.0", raw);
+        }
+
+        [Fact]
+        public void TryParsePwshVersionOutput_NoiseLineBeforeVersion_ParsesLastLine()
+        {
+            bool success = CPowerShellVersionChecker.TryParsePwshVersionOutput("Update available: 7.6.1\n7.4.6", out Version installed, out string raw);
+
+            Assert.True(success);
+            Assert.Equal(Version.Parse("7.4.6"), installed);
+            Assert.Equal("7.4.6", raw);
+        }
+
+        [Fact]
+        public void TryParseManifestContent_CommentedOutEntryPrecedingLiveEntry_ParsesLiveEntry()
+        {
+            bool success = CPowerShellVersionChecker.TryParseManifestContent(
+                "# PowerShellVersion = '5.1'\nPowerShellVersion = '7.6'",
+                out Version required);
+
+            Assert.True(success);
+            Assert.Equal(Version.Parse("7.6"), required);
+        }
+
+        [Fact]
+        public void TryParseManifestContent_EntirelyCommentedOutEntry_ReturnsFalse()
+        {
+            bool success = CPowerShellVersionChecker.TryParseManifestContent("# PowerShellVersion = '5.1'", out Version required);
+
+            Assert.False(success);
+            Assert.Null(required);
+        }
     }
 }

--- a/vHC/VhcXTests/PSInvokerFindExecutableTests.cs
+++ b/vHC/VhcXTests/PSInvokerFindExecutableTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using System.IO;
+using System.Reflection;
+using VeeamHealthCheck.Functions.Collection.PSCollections;
+using Xunit;
+
+namespace VhcXTests
+{
+    /// <summary>
+    /// Regression tests for FindExecutableInPath's hardcoded pwsh.exe fallback, which previously
+    /// returned the default install path unconditionally (no File.Exists check) - unlike
+    /// CPowerShellVersionChecker.FindPwshExecutable - causing ExecutePsScriptWithFailover's
+    /// "try PS7, then PS5" loop to always attempt a nonexistent path instead of falling back to
+    /// PS5 when pwsh isn't installed at all.
+    ///
+    /// Naming convention: [Method]_[Scenario]_[Expected].
+    /// </summary>
+    [Collection("GlobalState")]
+    public class PSInvokerFindExecutableTests : IDisposable
+    {
+        private const string DefaultPwshPath = @"C:\Program Files\PowerShell\7\pwsh.exe";
+        private readonly string? _origPath;
+
+        public PSInvokerFindExecutableTests()
+        {
+            _origPath = Environment.GetEnvironmentVariable("PATH");
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("PATH", _origPath);
+        }
+
+        private static string? InvokeFindExecutableInPath(string exeName)
+        {
+            var method = typeof(PSInvoker).GetMethod("FindExecutableInPath", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return (string?)method!.Invoke(new PSInvoker(), new object[] { exeName });
+        }
+
+        [Fact]
+        public void FindExecutableInPath_PwshInPathDirectory_ReturnsPath()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"vhc-pwsh-path-{Guid.NewGuid()}");
+            Directory.CreateDirectory(tempDir);
+            string stubPwsh = Path.Combine(tempDir, "pwsh.exe");
+            File.WriteAllText(stubPwsh, string.Empty);
+
+            try
+            {
+                Environment.SetEnvironmentVariable("PATH", tempDir + Path.PathSeparator + _origPath);
+
+                string? result = InvokeFindExecutableInPath("pwsh.exe");
+
+                Assert.Equal(stubPwsh, result);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
+        public void FindExecutableInPath_DefaultPathMissing_ReturnsNull()
+        {
+            // This regression guard only applies when the CI image doesn't happen to have
+            // PowerShell 7 installed at the literal hardcoded default path - if it does, the
+            // "missing" branch can't be exercised on that machine, so skip rather than assert
+            // falsely.
+            if (File.Exists(DefaultPwshPath))
+            {
+                return;
+            }
+
+            // Point PATH at a directory guaranteed not to contain pwsh.exe, removing the
+            // PATH-hit branch so only the hardcoded-default fallback is exercised.
+            string emptyDir = Path.Combine(Path.GetTempPath(), $"vhc-pwsh-empty-{Guid.NewGuid()}");
+            Directory.CreateDirectory(emptyDir);
+
+            try
+            {
+                Environment.SetEnvironmentVariable("PATH", emptyDir);
+
+                string? result = InvokeFindExecutableInPath("pwsh.exe");
+
+                Assert.Null(result);
+            }
+            finally
+            {
+                Directory.Delete(emptyDir, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- VBR 13.1 raised the `Veeam.Backup.PowerShell` module's minimum PowerShell requirement to 7.6. vHC only checked "PS7 required for VBR 13+" without checking *which* 7.x, so PowerShell 7.4.x installs pass our precheck and then fail deep inside `TestMfa.ps1` with a confusing `Get-Package` / `Import-Module` / `Connect-VBRServer` error cascade.
- Adds a preflight check (`CPowerShellVersionChecker`) that reads the required version from the installed module's `.psd1` manifest (not hardcoded, since Veeam can raise it again) and compares it against the actual installed `pwsh` version.
- **Confirmed shortfall = hard fail.** If the installed PS7 is below the manifest's required version, this exits the process immediately (`Environment.Exit`, before any collection is attempted) with a clear, actionable message. It does not warn-and-continue.
- **Inconclusive = soft skip.** If the manifest can't be found/parsed, or `pwsh.exe` can't be located at all, the check skips and falls through to prior behavior, so a non-standard install path or an unanticipated manifest format can't turn a currently-working setup into a false abort. This is the only "soft" part of this change.

## Test plan
- [x] `dotnet build vHC/HC_Reporting/VeeamHealthCheck.csproj` — 0 errors
- [x] `dotnet test vHC/VhcXTests/VhcXTests.csproj` on Windows CI (new unit tests for manifest/version parsing in `CPowerShellVersionCheckerTests.cs`; test compilation is skipped on this non-Windows dev machine per the csproj's platform guard, so unverified locally)
- [x] Manual repro on a machine with PowerShell 7.4.x + VBR 13.1 console per issue #186, confirm the new error message appears instead of the TestMfa.ps1 crash

Fixes #186