### PR TITLE
fix(collection): fall back to GetPhysicalHost() for OS Version when Info.Info is blank

### DIFF
--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcServer.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcServer.ps1
@@ -25,7 +25,35 @@ function Get-VhcServer {
             @{ name = 'Cores';    expression = { $_.GetPhysicalHost().hardwareinfo.CoresCount       } },
             @{ name = 'CPUCount'; expression = { $_.GetPhysicalHost().hardwareinfo.CPUCount          } },
             @{ name = 'RAM';      expression = { $_.GetPhysicalHost().hardwareinfo.PhysicalRamTotal  } },
-            @{ name = 'OSInfo';   expression = { $_.Info.Info                                        } },
+            @{ name = 'OSInfo';   expression = {
+                # $_.Info.Info holds a good caption for hypervisor-managed hosts (e.g. ESXi:
+                # "VMware ESXi 8.0.2 build-23305546") but is unpopulated for the backup
+                # server's own host record. Only fall back to GetPhysicalHost() when the
+                # primary source is empty, since GetPhysicalHost().OsType reports "Other"
+                # for host types like ESXi where Info.Info is the better source.
+                try {
+                    if ($_.Info -and $_.Info.Info) {
+                        return $_.Info.Info
+                    }
+
+                    $physHost = @($_.GetPhysicalHost())[0]
+                    if (-not $physHost) { return '' }
+
+                    $unixInfo = $null
+                    $unixProp = $physHost.PSObject.Properties['UnixBasedOsInfo']
+                    if ($unixProp) { $unixInfo = $unixProp.Value }
+
+                    if ($unixInfo) {
+                        "$($unixInfo.Type) $($unixInfo.DistribVersion)".Trim()
+                    } elseif ($null -ne $physHost.OsType -and $physHost.OsType.ToString() -notin @('Other', 'Unknown')) {
+                        $physHost.OsType.ToString()
+                    } else {
+                        ''
+                    }
+                } catch {
+                    ''
+                }
+            } },
             @{ name = 'Platform'; expression = {
                 $key = if ($_.Name) { $_.Name.ToLowerInvariant() } else { '' }
                 if ($script:PlatformMap -and $script:PlatformMap.ContainsKey($key)) {

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcServer.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcServer.ps1
@@ -26,6 +26,7 @@ function Get-VhcServer {
             @{ name = 'CPUCount'; expression = { $_.GetPhysicalHost().hardwareinfo.CPUCount          } },
             @{ name = 'RAM';      expression = { $_.GetPhysicalHost().hardwareinfo.PhysicalRamTotal  } },
             @{ name = 'OSInfo';   expression = {
+                $server = $_
                 # $_.Info.Info holds a good caption for hypervisor-managed hosts (e.g. ESXi:
                 # "VMware ESXi 8.0.2 build-23305546") but is unpopulated for the backup
                 # server's own host record. Only fall back to GetPhysicalHost() when the
@@ -54,6 +55,7 @@ function Get-VhcServer {
                         ''
                     }
                 } catch {
+                    Write-LogFile "OS info unavailable for '$($server.Name)' - defaulting to blank OS Version." -LogLevel "WARNING"
                     ''
                 }
             } },

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcServer.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcServer.ps1
@@ -43,7 +43,10 @@ function Get-VhcServer {
                     $unixProp = $physHost.PSObject.Properties['UnixBasedOsInfo']
                     if ($unixProp) { $unixInfo = $unixProp.Value }
 
-                    if ($unixInfo) {
+                    # VBR reports Type='Unknown'/DistribVersion='0.0' as a sentinel for
+                    # non-OS-bearing entries (e.g. ExternalInfrastructureServer); treat
+                    # that as no data rather than surfacing a fabricated OS caption.
+                    if ($unixInfo -and $unixInfo.Type -and $unixInfo.Type -ne 'Unknown') {
                         "$($unixInfo.Type) $($unixInfo.DistribVersion)".Trim()
                     } elseif ($null -ne $physHost.OsType -and $physHost.OsType.ToString() -notin @('Other', 'Unknown')) {
                         $physHost.OsType.ToString()


### PR DESCRIPTION
## Summary

- Fixes the OS Version column in the "Backup Server & Config DB Info" table (and the "Detected OS" / Managed Server tables) being blank for the VBR backup server's own host record.
- Root cause: `Get-VBRServer`'s `Info.Info` property is never populated for the backup server's self-registered host record on either VBR 12.3 (Windows) or VBR 13.1 (Linux VSA) — confirmed via live testing across two environments, not a version-specific regression.
- `Get-VhcServer.ps1` now keeps `Info.Info` as the primary source (unchanged for ESXi/vCenter/explicitly-managed servers, where it already gives good captions) and only falls back to `GetPhysicalHost()` when `Info.Info` is empty, filtering out non-informative `Other`/`Unknown` enum values.

Fixes #190

## Test plan

- [x] `pwsh` parse-check on the modified script (no syntax errors)
- [x] Logic simulated against real `Info.Info` / `GetPhysicalHost()` shapes captured from live VBR 12.3 and VBR 13.1 environments (ESXi, vCenter, explicitly-managed Windows server, Local Windows backup server, Local Linux VSA backup server) — every row produces the expected value, no regressions for host types where `Info.Info` already worked
- [x] Verify the "Backup Server & Config DB Info" OS Version column renders correctly against a live health check run (Windows and Linux VSA backup servers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
