### PR TITLE
fix(startup): hard-fail when PowerShell 7 is missing entirely, not just too old

### DIFF
--- a/docs/superpowers/specs/2026-08-28-pwsh-missing-preflight-design.md
+++ b/docs/superpowers/specs/2026-08-28-pwsh-missing-preflight-design.md
@@ -1,0 +1,200 @@
+# PowerShell 7 Missing/Broken Preflight (Issue #135) — Design
+
+**Date:** 2026-08-28
+**Status:** Proposed
+
+## Problem
+
+Issue #135 asked for a startup preflight that validates PowerShell 7 is
+installed and warns clearly if it's missing or broken, instead of letting VHC
+fail deep inside a collection script with a confusing PowerShell-level error.
+
+Related work landed since (#186/#187, commits `b484462`/`7d75cea`/`594afea`)
+added `CClientFunctions.ValidatePowerShellVersionMeetsVbrRequirement()`, which
+compares the installed PS7 version against the minimum the local
+`Veeam.Backup.PowerShell` module manifest requires, and hard-exits with an
+actionable message if it's too old. That check is correctly scoped: it only
+runs when `CGlobals.PowerShellVersion == 7`, which is only set when
+`VBRMAJORVERSION >= 13` (`CClientFunctions.cs:557`) — so it never fires
+redundantly for pre-v13 targets that only need PowerShell 5.1.
+
+The remaining gap is inside that VBR-13+ path itself. When
+`CPowerShellVersionChecker.TryGetInstalledPwshVersion` can't determine an
+installed version, `ValidatePowerShellVersionMeetsVbrRequirement()` currently
+treats that as one undifferentiated case: Debug-log and silently continue
+(`CClientFunctions.cs:614-618`). That method returns `false` both when PS7 is
+genuinely absent (`FindPwshExecutable()` found nothing) and when detection
+itself was merely inconclusive (process timeout, unparsable output). The
+first case is exactly what #135 reported and it's still unhandled: the run
+proceeds and fails later with the confusing error #135 exists to prevent.
+
+## Solution
+
+Distinguish "PS7 not installed anywhere" from "PS7 present but version
+undeterminable," and hard-fail only the former (reusing the existing
+`PowerShellVersionUnsupported` exit path and exit code 8), while keeping the
+latter as a soft skip — same conservative behavior as today, to avoid a false
+positive block on a transient detection hiccup when PS7 may in fact be fine.
+
+The manifest-required-version read can itself fail independently of pwsh's
+presence (`VbrConsoleInstallDir` unknown, or the manifest unparsable), and
+today that failure short-circuits the method before pwsh presence is even
+checked. Left unchanged, "PS7 completely absent *and* the manifest can't be
+read" would still silently pass through — the exact #135 failure, just from a
+different trigger. `EvaluatePwshVersionStatus` (below) checks `pwshPath`
+first and unconditionally, so `NotInstalled` is returned whether or not the
+manifest read succeeded, closing that residual path without restructuring
+the method's read order.
+
+Broadening the hard-fail to cover "undeterminable" too (closer to #135's
+literal title, which also says "broken") was considered and rejected: it
+risks blocking valid runs on a one-off timeout or an unexpected output format,
+a risk class the #186/#187 work was deliberately careful about elsewhere. A
+fully standalone startup preflight (independent of the existing VBR-targeting
+gate) was also considered and rejected: it would re-open the exact call-site
+issues that took three follow-up commits (`594afea`, `c8bf129`, `15296c1`) to
+fix — GUI hard-exit before the window renders, double pwsh spawn, incorrectly
+gating `/hotfix` and `/import`. The existing choke point
+(`RunVbrPreflightGateIfTargeted` → `ValidatePowerShellVersionMeetsVbrRequirement`)
+already reaches the case that needs fixing.
+
+## Architecture
+
+```
+CClientFunctions.ValidatePowerShellVersionMeetsVbrRequirement()  (modified)
+    │
+    ├─ pwshPath = CPowerShellVersionChecker.FindPwshExecutable()   (visibility: private → internal)
+    ├─ requiredVersion = best-effort manifest read (unchanged shape: null if
+    │      VbrConsoleInstallDir unknown or manifest unparsable - no longer an
+    │      early return, just an input to the status function below)
+    ├─ if pwshPath found:
+    │      TryGetInstalledPwshVersion(pwshPath, out installedVersion, out rawVersion)
+    │      (signature change: takes pwshPath instead of re-resolving it)
+    │
+    ├─ status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+    │               pwshPath, installedVersion, requiredVersion)   (new, pure;
+    │               requiredVersion is nullable)
+    │
+    └─ switch (status):
+           MeetsRequirement      → return
+           VersionInconclusive   → Debug-log, return   (covers: manifest unreadable,
+                                                          OR pwsh present but version
+                                                          undeterminable - unchanged
+                                                          soft-skip behavior)
+           NotInstalled          → BuildPwshVersionFailureMessage(...), hard-fail (exit code 8)
+           BelowRequirement      → BuildPwshVersionFailureMessage(...), hard-fail (exit code 8)
+```
+
+`NotInstalled` is checked first inside `EvaluatePwshVersionStatus`,
+independent of whether `requiredVersion` resolved — this is what makes "PS7
+missing *and* manifest unreadable" correctly hard-fail instead of silently
+passing through the old manifest early-return.
+
+`EvaluatePwshVersionStatus` and `BuildPwshVersionFailureMessage` both live in
+`CPowerShellVersionChecker.cs` (the pure, no-WPF/no-CCollections half of the
+partial class), so they stay linked into `VhcXTests.CrossPlatform` alongside
+the existing manifest/version parsing tests and are verifiable in CI without
+Windows.
+
+## Components
+
+**`CPowerShellVersionChecker.cs`** (pure half)
+- `FindPwshExecutable()`: `private` → `internal`, so
+  `ValidatePowerShellVersionMeetsVbrRequirement` can resolve the path once and
+  reuse it, instead of `TryGetInstalledPwshVersion` re-scanning PATH
+  internally.
+- New: `PwshVersionStatus` enum — `MeetsRequirement`, `NotInstalled`,
+  `VersionInconclusive`, `BelowRequirement`.
+- New: `EvaluatePwshVersionStatus(string? pwshPath, Version? installedVersion, Version? requiredVersion) -> PwshVersionStatus`
+  (`requiredVersion` is nullable — the manifest read can fail independently of
+  pwsh's presence). Pure function, no I/O, checked in this order:
+  - `pwshPath` null/empty → `NotInstalled` (checked first and unconditionally,
+    so a simultaneously-unreadable manifest can't mask this case — see
+    Solution)
+  - `requiredVersion` null → `VersionInconclusive` (manifest unreadable/unparsable)
+  - `installedVersion` null → `VersionInconclusive` (pwsh present but version undeterminable)
+  - `installedVersion < requiredVersion` → `BelowRequirement`
+  - else → `MeetsRequirement`
+- New: `BuildPwshVersionFailureMessage(PwshVersionStatus status, string vbrFullVersion, Version? requiredVersion, string? rawInstalledVersion) -> string`.
+  Pure function, no I/O. Only ever called for `NotInstalled`/`BelowRequirement`:
+  - `NotInstalled`: "...requires PowerShell {requiredVersion} or higher" when
+    `requiredVersion` happens to be known, else the generic "...requires
+    PowerShell 7" (manifest may not have been readable); "...but no
+    PowerShell 7 installation was found on this computer. Install PowerShell
+    7 (https://aka.ms/powershell-release?tag=stable) and re-run..."
+  - `BelowRequirement`: today's existing message text, unchanged, just
+    relocated into this pure function so it's directly unit-testable (see
+    Testing).
+
+**`CPowerShellVersionChecker.Invocation.cs`**
+- `TryGetInstalledPwshVersion` signature changes from
+  `TryGetInstalledPwshVersion(out Version installedVersion, out string rawVersion)`
+  to `TryGetInstalledPwshVersion(string pwshPath, out Version installedVersion, out string rawVersion)`.
+  Drops its internal `FindPwshExecutable()` call; returns `false` immediately
+  if `pwshPath` is null/empty (preserves current behavior for that case,
+  just driven by the caller-supplied path instead of a redundant lookup).
+
+**`CClientFunctions.cs`**
+- `ValidatePowerShellVersionMeetsVbrRequirement()`: resolve `pwshPath` and the
+  best-effort `requiredVersion` (the existing manifest read, kept as-is
+  except it's no longer an early `return` — a null result just flows into
+  `EvaluatePwshVersionStatus`), call `TryGetInstalledPwshVersion` only when a
+  path was found, compute `status`, and switch on it as shown in Architecture.
+  For `NotInstalled`/`BelowRequirement`, get the message from
+  `BuildPwshVersionFailureMessage` and route through the existing hard-fail
+  plumbing unchanged (`LOG.Error`, `Silent`/`GUIEXEC` branches,
+  `Environment.Exit(SilentExit.PowerShellVersionUnsupported)` — reusing exit
+  code 8, since both are the same underlying failure class: the installed
+  PowerShell doesn't meet the VBR module's requirement).
+
+**`CMessages.cs`**
+- Line 95's silent-mode help text for exit code 8 currently reads "Installed
+  PowerShell version is below what the VBR PowerShell module requires,"
+  which is only accurate for the `BelowRequirement` sub-case. Update it to
+  cover both, e.g. "PowerShell 7 missing, or its installed version is below
+  what the VBR PowerShell module requires."
+
+## Testing (TDD)
+
+`ValidatePowerShellVersionMeetsVbrRequirement` reaches `SilentExit.ExitSilent`
+or `Environment.Exit` directly on the hard-fail paths — both kill the process
+unconditionally, with no test seam, and `CClientFunctionsGateTests.cs`'s
+existing reflection tests only assert method visibility; none of them invoke
+a gated method's hard-fail branch or inspect message content. So all new
+logic is pushed into the two pure functions above, which are fully
+unit-testable without touching the process-exit paths:
+
+- `VhcXTests.CrossPlatform`: new tests for `EvaluatePwshVersionStatus` (all
+  four branches, including the priority case that fixes the residual gap —
+  `pwshPath` null with `requiredVersion` also null must still return
+  `NotInstalled`, not `VersionInconclusive`) and for
+  `BuildPwshVersionFailureMessage` (both statuses, and `NotInstalled` with
+  `requiredVersion` both known and null), following the existing
+  `CPowerShellVersionCheckerParsingTests.cs` pattern. `FindPwshExecutable`
+  itself is an existing, already-implemented method (only its visibility
+  changes) and needs no new test coverage.
+- `VhcXTests`: mirror the same `EvaluatePwshVersionStatus` and
+  `BuildPwshVersionFailureMessage` cases into
+  `CPowerShellVersionCheckerTests.cs` (Windows-only mirror of the
+  cross-platform tests, matching the existing duplication convention for this
+  file).
+- `CClientFunctionsGateTests.cs`: no changes. This fix doesn't alter the
+  gate's call-site contract (`RunVbrPreflightGateIfTargeted` → private
+  `GetVbrVersion` → `ValidatePowerShellVersionMeetsVbrRequirement` stays
+  exactly as reachable/private as today), so there's nothing new for that
+  file's structural tests to cover, and — per the untestable-exit-path
+  problem above — no way to add a meaningful behavioral test there anyway.
+
+## Out of scope
+
+- Treating a "found but broken" pwsh.exe (e.g., corrupted binary that starts
+  but crashes) as a hard failure — falls under `VersionInconclusive`,
+  unchanged soft-skip behavior, per the false-positive-risk rationale above.
+- Any change to the pre-v13 (PowerShell 5.1) path — already correctly
+  unaffected by this check.
+- A standalone/earlier startup preflight independent of
+  `RunVbrPreflightGateIfTargeted` — rejected, see Solution above.
+
+## Branch
+
+`fix/issue-135-pwsh-missing-preflight`, off `dev`.

--- a/vHC/HC_Reporting/Common/CMessages.cs
+++ b/vHC/HC_Reporting/Common/CMessages.cs
@@ -92,7 +92,7 @@ UNATTENDED / SILENT MODE:
     5  Host unreachable
     6  /credfile= invalid (malformed JSON, missing fields, bad Base64)
     7  No Veeam product detected and no /host= provided
-    8  Installed PowerShell version is below what the VBR PowerShell module requires
+    8  PowerShell 7 missing, or its installed version is below what the VBR PowerShell module requires
 
   Worked example (Task Scheduler / 20-server fleet):
     Seed once on each server as the service account:

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.Invocation.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.Invocation.cs
@@ -19,12 +19,11 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
         /// Invokes pwsh.exe to read $PSVersionTable.PSVersion. Returns false if pwsh cannot be
         /// located, fails to exit within the timeout, or its output cannot be parsed.
         /// </summary>
-        public static bool TryGetInstalledPwshVersion(out Version installedVersion, out string rawVersion)
+        public static bool TryGetInstalledPwshVersion(string pwshPath, out Version installedVersion, out string rawVersion)
         {
             installedVersion = null;
             rawVersion = null;
 
-            string pwshPath = FindPwshExecutable();
             if (string.IsNullOrEmpty(pwshPath))
             {
                 return false;

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
@@ -127,7 +127,7 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             return Version.TryParse(numericPart, out installedVersion);
         }
 
-        private static string? FindPwshExecutable()
+        internal static string? FindPwshExecutable()
         {
             string? pathEnv = Environment.GetEnvironmentVariable("PATH");
             if (!string.IsNullOrEmpty(pathEnv))

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
@@ -12,7 +12,7 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
     /// required version. Kept separate from message text (see BuildPwshVersionFailureMessage) so
     /// both the decision and the wording are independently unit-testable.
     /// </summary>
-    internal enum PwshVersionStatus
+    public enum PwshVersionStatus
     {
         MeetsRequirement,
         NotInstalled,
@@ -172,6 +172,32 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             }
 
             return installedVersion < requiredVersion ? PwshVersionStatus.BelowRequirement : PwshVersionStatus.MeetsRequirement;
+        }
+
+        /// <summary>
+        /// Builds the actionable failure message for the NotInstalled and BelowRequirement statuses.
+        /// Never called for MeetsRequirement/VersionInconclusive - those aren't failures.
+        /// </summary>
+        internal static string BuildPwshVersionFailureMessage(PwshVersionStatus status, string vbrFullVersion, Version? requiredVersion, string? rawInstalledVersion)
+        {
+            string requirementClause = requiredVersion != null
+                ? $"requires PowerShell {requiredVersion} or higher"
+                : "requires PowerShell 7";
+
+            return status switch
+            {
+                PwshVersionStatus.NotInstalled =>
+                    $"The Veeam Backup & Replication PowerShell module (VBR {vbrFullVersion}) {requirementClause}, " +
+                    "but no PowerShell 7 installation was found on this computer. Install PowerShell 7 " +
+                    "(https://aka.ms/powershell-release?tag=stable) and re-run Veeam Health Check.",
+
+                PwshVersionStatus.BelowRequirement =>
+                    $"The Veeam Backup & Replication PowerShell module (VBR {vbrFullVersion}) {requirementClause}, " +
+                    $"but this computer has PowerShell {rawInstalledVersion} installed. Install a newer PowerShell 7 " +
+                    "release (https://aka.ms/powershell-release?tag=stable) and re-run Veeam Health Check.",
+
+                _ => throw new ArgumentOutOfRangeException(nameof(status), status, "BuildPwshVersionFailureMessage only supports NotInstalled and BelowRequirement.")
+            };
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
@@ -8,6 +8,19 @@ using System.Text.RegularExpressions;
 namespace VeeamHealthCheck.Functions.Collection.PSCollections
 {
     /// <summary>
+    /// Outcome of comparing an installed PowerShell 7 against the VBR PowerShell module's minimum
+    /// required version. Kept separate from message text (see BuildPwshVersionFailureMessage) so
+    /// both the decision and the wording are independently unit-testable.
+    /// </summary>
+    internal enum PwshVersionStatus
+    {
+        MeetsRequirement,
+        NotInstalled,
+        VersionInconclusive,
+        BelowRequirement
+    }
+
+    /// <summary>
     /// Determines whether the PowerShell 7 install on this machine meets the minimum version
     /// required by the installed Veeam.Backup.PowerShell module, so callers can fail fast with an
     /// actionable message instead of letting Import-Module abort deep inside a collection script.
@@ -138,6 +151,27 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
 
             const string defaultPath = @"C:\Program Files\PowerShell\7\pwsh.exe";
             return File.Exists(defaultPath) ? defaultPath : null;
+        }
+
+        /// <summary>
+        /// Decides what, if anything, is wrong with the installed PowerShell 7 relative to what the
+        /// VBR PowerShell module requires. NotInstalled is checked first and unconditionally so a
+        /// simultaneously-unreadable module manifest (requiredVersion null) can never mask a
+        /// completely missing PowerShell 7 install - the scenario issue #135 was filed about.
+        /// </summary>
+        internal static PwshVersionStatus EvaluatePwshVersionStatus(string? pwshPath, Version? installedVersion, Version? requiredVersion)
+        {
+            if (string.IsNullOrEmpty(pwshPath))
+            {
+                return PwshVersionStatus.NotInstalled;
+            }
+
+            if (requiredVersion == null || installedVersion == null)
+            {
+                return PwshVersionStatus.VersionInconclusive;
+            }
+
+            return installedVersion < requiredVersion ? PwshVersionStatus.BelowRequirement : PwshVersionStatus.MeetsRequirement;
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/CPowerShellVersionChecker.cs
@@ -12,7 +12,7 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
     /// required version. Kept separate from message text (see BuildPwshVersionFailureMessage) so
     /// both the decision and the wording are independently unit-testable.
     /// </summary>
-    public enum PwshVersionStatus
+    internal enum PwshVersionStatus
     {
         MeetsRequirement,
         NotInstalled,

--- a/vHC/HC_Reporting/Startup/CClientFunctions.cs
+++ b/vHC/HC_Reporting/Startup/CClientFunctions.cs
@@ -500,9 +500,10 @@ namespace VeeamHealthCheck.Startup
         /// local VBR actually detected) regardless of REMOTEEXEC: per repo convention, a preflight
         /// on the local PowerShell/module install must run regardless of REMOTEEXEC, since it is
         /// never the remote machine's problem. GetVbrVersion -> DetectVbrVersion throws by design
-        /// when local VBR detection fails - not fatal, the preflight just can't run. This never
-        /// swallows a genuine too-old-PowerShell failure: that path terminates via
-        /// Environment.Exit / SilentExit.ExitSilent, neither of which throws.
+        /// when local VBR detection fails - not fatal, the preflight just can't run; GetVbrVersion
+        /// catches only that expected failure, scoped to the DetectVbrVersion call, so an exception
+        /// out of the hard-fail path (ValidatePowerShellVersionMeetsVbrRequirement) is never
+        /// mistaken for it and swallowed here too.
         /// </summary>
         internal void RunVbrPreflightGateIfTargeted()
         {
@@ -511,14 +512,7 @@ namespace VeeamHealthCheck.Startup
                 return;
             }
 
-            try
-            {
-                this.GetVbrVersion();
-            }
-            catch (Exception ex)
-            {
-                this.LOG.Debug(this.logStart + $"PowerShell version gate skipped: {ex.Message}");
-            }
+            this.GetVbrVersion();
         }
 
         /// <summary>
@@ -530,10 +524,26 @@ namespace VeeamHealthCheck.Startup
         /// Every other caller (ModeCheck, RunHotfixDetector, early CLI arg-parsing detection)
         /// must call the ungated DetectVbrVersion instead, so a too-old-PowerShell machine
         /// doesn't hard-exit a feature that never touches the Veeam.Backup.PowerShell module.
+        /// Known limitation, not fixed here: when DetectVbrVersion fails (e.g. non-admin
+        /// execution, where CRegReader.GetVbrVersionFilePath() returns null), we can't know
+        /// whether the local VBR is 13+ at all, so ValidatePowerShellVersionMeetsVbrRequirement
+        /// is skipped rather than called - it would no-op anyway, since it gates on
+        /// CGlobals.PowerShellVersion, which DetectVbrVersion only ever sets on success. Making
+        /// this reachable needs VBR-version detection to work without admin rights first; that's
+        /// separate, larger work in CRegReader, not a fix to this gate's catch scope.
         /// </summary>
         private void GetVbrVersion()
         {
-            this.DetectVbrVersion();
+            try
+            {
+                this.DetectVbrVersion();
+            }
+            catch (Exception ex)
+            {
+                this.LOG.Debug(this.logStart + $"PowerShell version gate skipped: {ex.Message}");
+                return;
+            }
+
             this.ValidatePowerShellVersionMeetsVbrRequirement();
         }
 
@@ -618,9 +628,13 @@ namespace VeeamHealthCheck.Startup
                 }
             }
 
+            // Only worth spawning pwsh.exe to read the installed version when a required version
+            // is actually known - EvaluatePwshVersionStatus treats a null requiredVersion as
+            // VersionInconclusive regardless of installedVersion, so the spawn would be wasted.
             Version installedVersion = null;
             string rawInstalledVersion = null;
-            if (!string.IsNullOrEmpty(pwshPath) && !CPowerShellVersionChecker.TryGetInstalledPwshVersion(pwshPath, out installedVersion, out rawInstalledVersion))
+            if (!string.IsNullOrEmpty(pwshPath) && requiredVersion != null &&
+                !CPowerShellVersionChecker.TryGetInstalledPwshVersion(pwshPath, out installedVersion, out rawInstalledVersion))
             {
                 this.LOG.Debug(this.logStart + "Could not determine installed PowerShell 7 version.");
             }
@@ -650,7 +664,17 @@ namespace VeeamHealthCheck.Startup
 
             if (CGlobals.Silent)
             {
-                SilentExit.ExitSilent(SilentExit.PowerShellVersionUnsupported, msg);
+                // Guarded like the GUIEXEC branch below: ExitSilent's Console.Error.WriteLine
+                // could throw (e.g. a broken/redirected stderr pipe), and this hard-fail must
+                // still reach Environment.Exit either way.
+                try
+                {
+                    SilentExit.ExitSilent(SilentExit.PowerShellVersionUnsupported, msg);
+                }
+                catch (Exception ex)
+                {
+                    this.LOG.Debug(this.logStart + $"ExitSilent failed: {ex.Message}");
+                }
             }
 
             if (CGlobals.GUIEXEC)
@@ -661,15 +685,24 @@ namespace VeeamHealthCheck.Startup
                 // convention in VhcGui.xaml.cs's ShowCollectionWarningsIfAny. Fall back to an
                 // undocked MessageBox.Show if there's no Dispatcher to marshal to - the user must
                 // still see this message before the Environment.Exit below, never silently.
-                System.Windows.Threading.Dispatcher dispatcher = Application.Current?.Dispatcher;
-                if (dispatcher != null)
+                // Guarded: dispatcher.Invoke/MessageBox.Show can itself throw (e.g. Dispatcher
+                // shutting down), and this hard-fail must reach Environment.Exit either way.
+                try
                 {
-                    dispatcher.Invoke(() =>
-                        MessageBox.Show(msg, "Unsupported PowerShell Version", MessageBoxButton.OK, MessageBoxImage.Error));
+                    System.Windows.Threading.Dispatcher dispatcher = Application.Current?.Dispatcher;
+                    if (dispatcher != null)
+                    {
+                        dispatcher.Invoke(() =>
+                            MessageBox.Show(msg, "Unsupported PowerShell Version", MessageBoxButton.OK, MessageBoxImage.Error));
+                    }
+                    else
+                    {
+                        MessageBox.Show(msg, "Unsupported PowerShell Version", MessageBoxButton.OK, MessageBoxImage.Error);
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    MessageBox.Show(msg, "Unsupported PowerShell Version", MessageBoxButton.OK, MessageBoxImage.Error);
+                    this.LOG.Debug(this.logStart + $"Failed to show PowerShell version MessageBox: {ex.Message}");
                 }
             }
 

--- a/vHC/HC_Reporting/Startup/CClientFunctions.cs
+++ b/vHC/HC_Reporting/Startup/CClientFunctions.cs
@@ -627,15 +627,21 @@ namespace VeeamHealthCheck.Startup
 
             PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(pwshPath, installedVersion, requiredVersion);
 
-            if (status == PwshVersionStatus.MeetsRequirement)
+            switch (status)
             {
-                return;
-            }
+                case PwshVersionStatus.MeetsRequirement:
+                    return;
 
-            if (status == PwshVersionStatus.VersionInconclusive)
-            {
-                this.LOG.Debug(this.logStart + "Skipping PowerShell module version preflight check: could not conclusively determine the installed vs. required version.");
-                return;
+                case PwshVersionStatus.VersionInconclusive:
+                    this.LOG.Debug(this.logStart + "Skipping PowerShell module version preflight check: could not conclusively determine the installed vs. required version.");
+                    return;
+
+                case PwshVersionStatus.NotInstalled:
+                case PwshVersionStatus.BelowRequirement:
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(status), status, "Unhandled PwshVersionStatus in ValidatePowerShellVersionMeetsVbrRequirement.");
             }
 
             string msg = CPowerShellVersionChecker.BuildPwshVersionFailureMessage(status, CGlobals.VBRFULLVERSION, requiredVersion, rawInstalledVersion);

--- a/vHC/HC_Reporting/Startup/CClientFunctions.cs
+++ b/vHC/HC_Reporting/Startup/CClientFunctions.cs
@@ -579,16 +579,21 @@ namespace VeeamHealthCheck.Startup
         }
 
         /// <summary>
-        /// Preflight check for VBR 13+: compares the installed PowerShell 7 version against the
-        /// minimum required by the local Veeam.Backup.PowerShell module manifest, and exits with an
-        /// actionable message if it's too old. Without this, an under-versioned PowerShell only fails
+        /// Preflight check for VBR 13+: verifies PowerShell 7 is actually installed, and if so,
+        /// compares its version against the minimum required by the local Veeam.Backup.PowerShell
+        /// module manifest. Exits with an actionable message if PS7 is missing entirely, or if it's
+        /// installed but too old. Without this, a missing or under-versioned PowerShell only fails
         /// later, deep inside a collection script's Import-Module call, with a confusing error trail
-        /// (see issue: VBR 13.1 requires PowerShell 7.6, but a 7.4.x install produces cascading
-        /// Get-Package / Import-Module / Connect-VBRServer errors instead of a clear message).
+        /// (see issue: VBR 13.1 requires PowerShell 7.6, but a 7.4.x install - or no PS7 install at
+        /// all - produces cascading Get-Package / Import-Module / Connect-VBRServer errors instead of
+        /// a clear message).
         /// Reads the requirement from the manifest rather than hardcoding it, since Veeam can raise
-        /// the minimum again in a future VBR release. Skips (does not block the run) if the manifest
-        /// or installed pwsh version can't be determined - this is a best-effort UX improvement, not
-        /// a hard gate.
+        /// the minimum again in a future VBR release. A missing PS7 install is always a hard failure,
+        /// even if the manifest itself couldn't be read (see EvaluatePwshVersionStatus - NotInstalled
+        /// is checked first and unconditionally). Only skips (does not block the run) when PS7 is
+        /// present but its version - or the manifest's required version - couldn't be conclusively
+        /// determined; that remains a best-effort UX improvement, not a hard gate, to avoid a
+        /// false-positive block on a transient detection hiccup.
         /// </summary>
         private void ValidatePowerShellVersionMeetsVbrRequirement()
         {
@@ -597,34 +602,43 @@ namespace VeeamHealthCheck.Startup
                 return;
             }
 
+            string pwshPath = CPowerShellVersionChecker.FindPwshExecutable();
+
+            Version requiredVersion = null;
             if (string.IsNullOrEmpty(CGlobals.VbrConsoleInstallDir))
             {
-                this.LOG.Debug(this.logStart + "VBR console install directory unknown. Skipping PowerShell module version preflight check.");
-                return;
+                this.LOG.Debug(this.logStart + "VBR console install directory unknown. Cannot read required PowerShell version from the module manifest.");
             }
-
-            string manifestPath = Path.Combine(CGlobals.VbrConsoleInstallDir, "Veeam.Backup.PowerShell", "Veeam.Backup.PowerShell.psd1");
-
-            if (!CPowerShellVersionChecker.TryGetManifestRequiredVersion(manifestPath, out Version requiredVersion))
+            else
             {
-                this.LOG.Debug(this.logStart + $"Could not read required PowerShell version from '{manifestPath}'. Skipping preflight check.");
-                return;
+                string manifestPath = Path.Combine(CGlobals.VbrConsoleInstallDir, "Veeam.Backup.PowerShell", "Veeam.Backup.PowerShell.psd1");
+                if (!CPowerShellVersionChecker.TryGetManifestRequiredVersion(manifestPath, out requiredVersion))
+                {
+                    this.LOG.Debug(this.logStart + $"Could not read required PowerShell version from '{manifestPath}'.");
+                }
             }
 
-            if (!CPowerShellVersionChecker.TryGetInstalledPwshVersion(out Version installedVersion, out string rawInstalledVersion))
+            Version installedVersion = null;
+            string rawInstalledVersion = null;
+            if (!string.IsNullOrEmpty(pwshPath) && !CPowerShellVersionChecker.TryGetInstalledPwshVersion(pwshPath, out installedVersion, out rawInstalledVersion))
             {
-                this.LOG.Debug(this.logStart + "Could not determine installed PowerShell 7 version. Skipping preflight check.");
-                return;
+                this.LOG.Debug(this.logStart + "Could not determine installed PowerShell 7 version.");
             }
 
-            if (installedVersion >= requiredVersion)
+            PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(pwshPath, installedVersion, requiredVersion);
+
+            if (status == PwshVersionStatus.MeetsRequirement)
             {
                 return;
             }
 
-            string msg = $"The Veeam Backup & Replication PowerShell module (VBR {CGlobals.VBRFULLVERSION}) requires PowerShell {requiredVersion} " +
-                         $"or higher, but this computer has PowerShell {rawInstalledVersion} installed. " +
-                         "Install a newer PowerShell 7 release (https://aka.ms/powershell-release?tag=stable) and re-run Veeam Health Check.";
+            if (status == PwshVersionStatus.VersionInconclusive)
+            {
+                this.LOG.Debug(this.logStart + "Skipping PowerShell module version preflight check: could not conclusively determine the installed vs. required version.");
+                return;
+            }
+
+            string msg = CPowerShellVersionChecker.BuildPwshVersionFailureMessage(status, CGlobals.VBRFULLVERSION, requiredVersion, rawInstalledVersion);
 
             this.LOG.Error(this.logStart + msg, false);
 

--- a/vHC/VhcXTests.CrossPlatform/CPowerShellVersionCheckerStatusTests.cs
+++ b/vHC/VhcXTests.CrossPlatform/CPowerShellVersionCheckerStatusTests.cs
@@ -95,7 +95,8 @@ public class CPowerShellVersionCheckerStatusTests
         string msg = CPowerShellVersionChecker.BuildPwshVersionFailureMessage(
             PwshVersionStatus.NotInstalled, "13.1.0.1234", requiredVersion: null, rawInstalledVersion: null);
 
-        Assert.Contains("requires PowerShell 7,", msg);
+        Assert.Contains("requires PowerShell 7", msg);
+        Assert.DoesNotContain("requires PowerShell 7.", msg); // Distinguishes generic (7) from specific (7.6 or higher)
         Assert.Contains("no PowerShell 7 installation was found", msg);
     }
 
@@ -112,12 +113,13 @@ public class CPowerShellVersionCheckerStatusTests
             msg);
     }
 
-    [Theory]
-    [InlineData(PwshVersionStatus.MeetsRequirement)]
-    [InlineData(PwshVersionStatus.VersionInconclusive)]
-    public void BuildPwshVersionFailureMessage_NonFailureStatus_ThrowsArgumentOutOfRangeException(PwshVersionStatus status)
+    [Fact]
+    public void BuildPwshVersionFailureMessage_NonFailureStatus_ThrowsArgumentOutOfRangeException()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            CPowerShellVersionChecker.BuildPwshVersionFailureMessage(status, "13.1.0.1234", Version.Parse("7.6"), "7.4.6"));
+            CPowerShellVersionChecker.BuildPwshVersionFailureMessage(PwshVersionStatus.MeetsRequirement, "13.1.0.1234", Version.Parse("7.6"), "7.4.6"));
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            CPowerShellVersionChecker.BuildPwshVersionFailureMessage(PwshVersionStatus.VersionInconclusive, "13.1.0.1234", Version.Parse("7.6"), "7.4.6"));
     }
 }

--- a/vHC/VhcXTests.CrossPlatform/CPowerShellVersionCheckerStatusTests.cs
+++ b/vHC/VhcXTests.CrossPlatform/CPowerShellVersionCheckerStatusTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using Xunit;
+using VeeamHealthCheck.Functions.Collection.PSCollections;
+
+namespace VhcXTests.CrossPlatform;
+
+public class CPowerShellVersionCheckerStatusTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void EvaluatePwshVersionStatus_PwshPathMissing_ReturnsNotInstalled(string? pwshPath)
+    {
+        PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+            pwshPath, installedVersion: null, requiredVersion: Version.Parse("7.6"));
+
+        Assert.Equal(PwshVersionStatus.NotInstalled, status);
+    }
+
+    [Fact]
+    public void EvaluatePwshVersionStatus_PwshPathMissingAndRequiredVersionAlsoNull_ReturnsNotInstalled()
+    {
+        // Regression case for issue #135: an unreadable module manifest (requiredVersion null)
+        // must never mask a completely missing PowerShell 7 install.
+        PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+            pwshPath: null, installedVersion: null, requiredVersion: null);
+
+        Assert.Equal(PwshVersionStatus.NotInstalled, status);
+    }
+
+    [Fact]
+    public void EvaluatePwshVersionStatus_PwshFoundButRequiredVersionUnknown_ReturnsVersionInconclusive()
+    {
+        PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+            pwshPath: @"C:\Program Files\PowerShell\7\pwsh.exe",
+            installedVersion: Version.Parse("7.6.0"),
+            requiredVersion: null);
+
+        Assert.Equal(PwshVersionStatus.VersionInconclusive, status);
+    }
+
+    [Fact]
+    public void EvaluatePwshVersionStatus_PwshFoundButInstalledVersionUndetermined_ReturnsVersionInconclusive()
+    {
+        PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+            pwshPath: @"C:\Program Files\PowerShell\7\pwsh.exe",
+            installedVersion: null,
+            requiredVersion: Version.Parse("7.6"));
+
+        Assert.Equal(PwshVersionStatus.VersionInconclusive, status);
+    }
+
+    [Fact]
+    public void EvaluatePwshVersionStatus_InstalledBelowRequired_ReturnsBelowRequirement()
+    {
+        PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+            pwshPath: @"C:\Program Files\PowerShell\7\pwsh.exe",
+            installedVersion: Version.Parse("7.4.6"),
+            requiredVersion: Version.Parse("7.6"));
+
+        Assert.Equal(PwshVersionStatus.BelowRequirement, status);
+    }
+
+    [Theory]
+    [InlineData("7.6.0")]
+    [InlineData("7.6.1")]
+    [InlineData("8.0.0")]
+    public void EvaluatePwshVersionStatus_InstalledMeetsOrExceedsRequired_ReturnsMeetsRequirement(string installedRaw)
+    {
+        PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+            pwshPath: @"C:\Program Files\PowerShell\7\pwsh.exe",
+            installedVersion: Version.Parse(installedRaw),
+            requiredVersion: Version.Parse("7.6"));
+
+        Assert.Equal(PwshVersionStatus.MeetsRequirement, status);
+    }
+}

--- a/vHC/VhcXTests.CrossPlatform/CPowerShellVersionCheckerStatusTests.cs
+++ b/vHC/VhcXTests.CrossPlatform/CPowerShellVersionCheckerStatusTests.cs
@@ -76,4 +76,48 @@ public class CPowerShellVersionCheckerStatusTests
 
         Assert.Equal(PwshVersionStatus.MeetsRequirement, status);
     }
+
+    [Fact]
+    public void BuildPwshVersionFailureMessage_NotInstalledWithKnownRequiredVersion_MentionsRequiredVersionAndInstallLink()
+    {
+        string msg = CPowerShellVersionChecker.BuildPwshVersionFailureMessage(
+            PwshVersionStatus.NotInstalled, "13.1.0.1234", Version.Parse("7.6"), rawInstalledVersion: null);
+
+        Assert.Contains("requires PowerShell 7.6 or higher", msg);
+        Assert.Contains("no PowerShell 7 installation was found", msg);
+        Assert.Contains("https://aka.ms/powershell-release?tag=stable", msg);
+        Assert.Contains("VBR 13.1.0.1234", msg);
+    }
+
+    [Fact]
+    public void BuildPwshVersionFailureMessage_NotInstalledWithUnknownRequiredVersion_UsesGenericPowerShell7Wording()
+    {
+        string msg = CPowerShellVersionChecker.BuildPwshVersionFailureMessage(
+            PwshVersionStatus.NotInstalled, "13.1.0.1234", requiredVersion: null, rawInstalledVersion: null);
+
+        Assert.Contains("requires PowerShell 7,", msg);
+        Assert.Contains("no PowerShell 7 installation was found", msg);
+    }
+
+    [Fact]
+    public void BuildPwshVersionFailureMessage_BelowRequirement_MatchesExistingMessageWording()
+    {
+        string msg = CPowerShellVersionChecker.BuildPwshVersionFailureMessage(
+            PwshVersionStatus.BelowRequirement, "13.1.0.1234", Version.Parse("7.6"), "7.4.6");
+
+        Assert.Equal(
+            "The Veeam Backup & Replication PowerShell module (VBR 13.1.0.1234) requires PowerShell 7.6 or higher, " +
+            "but this computer has PowerShell 7.4.6 installed. Install a newer PowerShell 7 release " +
+            "(https://aka.ms/powershell-release?tag=stable) and re-run Veeam Health Check.",
+            msg);
+    }
+
+    [Theory]
+    [InlineData(PwshVersionStatus.MeetsRequirement)]
+    [InlineData(PwshVersionStatus.VersionInconclusive)]
+    public void BuildPwshVersionFailureMessage_NonFailureStatus_ThrowsArgumentOutOfRangeException(PwshVersionStatus status)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            CPowerShellVersionChecker.BuildPwshVersionFailureMessage(status, "13.1.0.1234", Version.Parse("7.6"), "7.4.6"));
+    }
 }

--- a/vHC/VhcXTests/Functions/Collection/PSCollections/CPowerShellVersionCheckerTests.cs
+++ b/vHC/VhcXTests/Functions/Collection/PSCollections/CPowerShellVersionCheckerTests.cs
@@ -125,5 +125,110 @@ namespace VeeamHealthCheck.Tests.Functions.Collection.PSCollections
             Assert.False(success);
             Assert.Null(required);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void EvaluatePwshVersionStatus_PwshPathMissing_ReturnsNotInstalled(string pwshPath)
+        {
+            PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+                pwshPath, null, Version.Parse("7.6"));
+
+            Assert.Equal(PwshVersionStatus.NotInstalled, status);
+        }
+
+        [Fact]
+        public void EvaluatePwshVersionStatus_PwshPathMissingAndRequiredVersionAlsoNull_ReturnsNotInstalled()
+        {
+            PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+                null, null, null);
+
+            Assert.Equal(PwshVersionStatus.NotInstalled, status);
+        }
+
+        [Fact]
+        public void EvaluatePwshVersionStatus_PwshFoundButRequiredVersionUnknown_ReturnsVersionInconclusive()
+        {
+            PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+                @"C:\Program Files\PowerShell\7\pwsh.exe", Version.Parse("7.6.0"), null);
+
+            Assert.Equal(PwshVersionStatus.VersionInconclusive, status);
+        }
+
+        [Fact]
+        public void EvaluatePwshVersionStatus_PwshFoundButInstalledVersionUndetermined_ReturnsVersionInconclusive()
+        {
+            PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+                @"C:\Program Files\PowerShell\7\pwsh.exe", null, Version.Parse("7.6"));
+
+            Assert.Equal(PwshVersionStatus.VersionInconclusive, status);
+        }
+
+        [Fact]
+        public void EvaluatePwshVersionStatus_InstalledBelowRequired_ReturnsBelowRequirement()
+        {
+            PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+                @"C:\Program Files\PowerShell\7\pwsh.exe", Version.Parse("7.4.6"), Version.Parse("7.6"));
+
+            Assert.Equal(PwshVersionStatus.BelowRequirement, status);
+        }
+
+        [Theory]
+        [InlineData("7.6.0")]
+        [InlineData("7.6.1")]
+        [InlineData("8.0.0")]
+        public void EvaluatePwshVersionStatus_InstalledMeetsOrExceedsRequired_ReturnsMeetsRequirement(string installedRaw)
+        {
+            PwshVersionStatus status = CPowerShellVersionChecker.EvaluatePwshVersionStatus(
+                @"C:\Program Files\PowerShell\7\pwsh.exe", Version.Parse(installedRaw), Version.Parse("7.6"));
+
+            Assert.Equal(PwshVersionStatus.MeetsRequirement, status);
+        }
+
+        [Fact]
+        public void BuildPwshVersionFailureMessage_NotInstalledWithKnownRequiredVersion_MentionsRequiredVersionAndInstallLink()
+        {
+            string msg = CPowerShellVersionChecker.BuildPwshVersionFailureMessage(
+                PwshVersionStatus.NotInstalled, "13.1.0.1234", Version.Parse("7.6"), null);
+
+            Assert.Contains("requires PowerShell 7.6 or higher", msg);
+            Assert.Contains("no PowerShell 7 installation was found", msg);
+            Assert.Contains("https://aka.ms/powershell-release?tag=stable", msg);
+            Assert.Contains("VBR 13.1.0.1234", msg);
+        }
+
+        [Fact]
+        public void BuildPwshVersionFailureMessage_NotInstalledWithUnknownRequiredVersion_UsesGenericPowerShell7Wording()
+        {
+            string msg = CPowerShellVersionChecker.BuildPwshVersionFailureMessage(
+                PwshVersionStatus.NotInstalled, "13.1.0.1234", null, null);
+
+            Assert.Contains("requires PowerShell 7", msg);
+            Assert.DoesNotContain("requires PowerShell 7.", msg);
+            Assert.Contains("no PowerShell 7 installation was found", msg);
+        }
+
+        [Fact]
+        public void BuildPwshVersionFailureMessage_BelowRequirement_MatchesExistingMessageWording()
+        {
+            string msg = CPowerShellVersionChecker.BuildPwshVersionFailureMessage(
+                PwshVersionStatus.BelowRequirement, "13.1.0.1234", Version.Parse("7.6"), "7.4.6");
+
+            Assert.Equal(
+                "The Veeam Backup & Replication PowerShell module (VBR 13.1.0.1234) requires PowerShell 7.6 or higher, " +
+                "but this computer has PowerShell 7.4.6 installed. Install a newer PowerShell 7 release " +
+                "(https://aka.ms/powershell-release?tag=stable) and re-run Veeam Health Check.",
+                msg);
+        }
+
+        [Fact]
+        public void BuildPwshVersionFailureMessage_NonFailureStatus_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                CPowerShellVersionChecker.BuildPwshVersionFailureMessage(PwshVersionStatus.MeetsRequirement, "13.1.0.1234", Version.Parse("7.6"), "7.4.6"));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                CPowerShellVersionChecker.BuildPwshVersionFailureMessage(PwshVersionStatus.VersionInconclusive, "13.1.0.1234", Version.Parse("7.6"), "7.4.6"));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- VBR 13+ requires PowerShell 7, but the existing preflight check only hard-failed when an installed PS7 was too old — a completely missing PS7 install would previously be silently skipped whenever the module manifest also couldn't be read (an unreadable manifest short-circuited the check before pwsh's presence was even tested).
- Adds two pure, independently-unit-tested functions (`EvaluatePwshVersionStatus`, `BuildPwshVersionFailureMessage`) to `CPowerShellVersionChecker.cs`, then rewires `ValidatePowerShellVersionMeetsVbrRequirement()` in `CClientFunctions.cs` to resolve pwsh's presence and the manifest's required version independently, so a missing PS7 install is now always a hard failure with an actionable message (exit code 8), regardless of whether the manifest could be read.
- Updates the silent-mode exit-code-8 help text to mention the missing-PS7 case.
- Mirrors the new tests into the Windows-only `VhcXTests` suite alongside the existing cross-platform coverage.

Fixes #135

## Test plan
- [x] `dotnet test vHC/VhcXTests.CrossPlatform/VhcXTests.CrossPlatform.csproj` — 111/111 passing
- [x] `dotnet build vHC/HC.sln` — 0 errors
- [x] `dotnet build vHC/VhcXTests/VhcXTests.csproj` — builds clean locally (note: this project skips actual compilation on non-Windows, so full C# verification of the mirrored Windows-only test file happens in CI's Windows job on first push)
- [ ] CI Windows job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)