### PR TITLE
fix(reporting): stop HTML leaking into JSON export, drop dead fields, stamp VhcVersion

### DIFF
--- a/docs/adr/0028-nested-json-via-dedicated-property.md
+++ b/docs/adr/0028-nested-json-via-dedicated-property.md
@@ -93,3 +93,14 @@ None needed beyond compilation — this is a data-shape decision, not an
 empirical one. See
 [`docs/superpowers/specs/2026-08-24-orphaned-superseded-backups-design.md`](../superpowers/specs/2026-08-24-orphaned-superseded-backups-design.md)
 and the implementation plan's Task 7.
+
+## Addendum (2026-08-28)
+
+`cProtectedWorkloads`, the precedent property cited above, was removed
+from `CFullReportJson` by issue #172 — confirmed dead (assigned nowhere in
+the codebase; the real protected-workloads data has always lived in
+`Sections["protectedWorkloads"]`). This ADR's decision — a dedicated typed
+property for `OrphanedSupersededBackups`, bypassing `SetSection` — is
+unaffected; only the precedent example cited above no longer exists in
+the code. See
+[ADR 0029](0029-html-free-values-in-json-export-producers.md).

--- a/docs/adr/0029-html-free-values-in-json-export-producers.md
+++ b/docs/adr/0029-html-free-values-in-json-export-producers.md
@@ -129,3 +129,22 @@ contributed to a real defect shipping in the same PR:
 
 See [PR #203](https://github.com/VeeamHub/veeam-healthcheck/pull/203)
 for the full review and the fix commits.
+
+## Addendum 2 (2026-08-28)
+
+A subsequent xhigh code review of PR #203 raised a further point about
+gateway-host rendering that is clarified here rather than changed in
+code:
+
+- **Unconditional `|` → `<br>` conversion for `Host` is intentional, not
+  a missing guard.** The review noted that `CRepoTable.cs` and
+  `CHtmlTables.AddSobrExtTable` call `RenderMultiValueHtml(d.Host)`
+  unconditionally, unlike `CRegKeysTable`'s `multiValueKeys`-gated
+  approach, and asked whether a literal `|` in a single host value could
+  be corrupted the same way. It cannot in practice: `Host` is always
+  produced by `SetGateHosts`, which splits `GateHosts` on spaces --
+  DNS hostnames cannot contain `|`. The `multiValueKeys` guard exists
+  specifically because arbitrary registry string values *can* legitimately
+  contain a literal `|`; that risk doesn't apply to hostnames, so no
+  equivalent guard is needed (or worth the added plumbing) for gateway
+  hosts.

--- a/docs/adr/0029-html-free-values-in-json-export-producers.md
+++ b/docs/adr/0029-html-free-values-in-json-export-producers.md
@@ -132,9 +132,9 @@ for the full review and the fix commits.
 
 ## Addendum 2 (2026-08-28)
 
-A subsequent xhigh code review of PR #203 raised a further point about
-gateway-host rendering that is clarified here rather than changed in
-code:
+A subsequent xhigh code review of PR #203 raised two further points
+about gateway-host rendering that are clarified here rather than
+changed in code:
 
 - **Unconditional `|` → `<br>` conversion for `Host` is intentional, not
   a missing guard.** The review noted that `CRepoTable.cs` and
@@ -148,3 +148,17 @@ code:
   contain a literal `|`; that risk doesn't apply to hostnames, so no
   equivalent guard is needed (or worth the added plumbing) for gateway
   hosts.
+- **The gateway-host HTML format change (dropped commas and trailing
+  `<br>`) is a deliberate, if previously undocumented, consequence of
+  this ADR's Option C**, not an unrelated regression. The Decision
+  section above only says these three producers now join with `|`
+  instead of `<br>`; it doesn't call out that `SetGateHosts`' HTML
+  output *itself* changed shape -- the old code joined hosts with
+  `",<br>"` plus a trailing `<br>`, while the shared
+  `RenderMultiValueHtml` conversion (also used by the registry table)
+  produces a plain `<br>`-separated list with no comma and no trailing
+  break. Keeping the old comma/trailing-break format for gateway hosts
+  specifically would mean diverging per call site again -- the
+  per-call-site patching Option A rejected. This shape is confirmed by
+  the `SetGateHosts_SingleHost_NoTrailingDelimiter` test and is the
+  intended behavior going forward.

--- a/docs/adr/0029-html-free-values-in-json-export-producers.md
+++ b/docs/adr/0029-html-free-values-in-json-export-producers.md
@@ -1,0 +1,91 @@
+# ADR 0029: JSON Export Producers Emit HTML-Free Values; HTML Rendering Injects `<br>` at the Call Site
+
+* **Status:** Accepted
+* **Date:** 2026-08-28
+* **Decider:** Ben Thomas (@comnam90)
+* **Consulted:** Claude Code (design)
+
+## Context and Problem Statement
+
+Issue #171 reported that the JSON report (`*.json`) leaks raw HTML markup
+into field values: `regKeys`'s `AzureArchiveFreezingUnSupportedRegions`
+value and `serversRequirements`'s `Type` column both contain literal
+`<br>` tags. Root cause: `CDataFormer.RegOptions()` and
+`CDataFormer.SummarizeRoleTypes()` join multi-value fields with `<br>` so
+the value can be dropped straight into an HTML table cell, and that same
+joined string is then reused, unchanged, as the JSON value for the same
+section (`SetSection`/`Sections[key]`). A third, unreported instance of
+the identical pattern was found during triage: `CDataFormer.SetGateHosts()`
+joins SOBR gateway hostnames with `<br>`, feeding both HTML and the
+`Sections[...]` JSON entry written by `CRepoTable.cs`.
+
+There is no single choke point for JSON section values: `SetSection`/
+`Sections[key] = new HtmlSection {...}` is duplicated across six files
+(`CHtmlTables.cs`, `CRegKeysTable.cs`, `CManagedServerTable.cs`,
+`CRepoTable.cs`, `CProxyTable.cs`, `CJobSummaryInfoTable.cs`), each with
+its own local helper.
+
+## Considered Options
+
+### Option A — Sanitize at each JSON-capture call site
+
+Strip/replace `<br>` with a JSON-safe delimiter immediately before each of
+the (at least) three affected `SetSection` calls.
+
+**Rejected.** Fixes only the symptom, at a choke point that doesn't
+actually exist as a single shared function. Six-plus separately-duplicated
+`SetSection` helpers mean the same patch would need reapplying wherever a
+new HTML-formatted value is captured for JSON in the future — the bug
+class would recur.
+
+### Option B — Consolidate all `SetSection` call sites into one shared helper first, then sanitize once
+
+**Rejected for this change.** A real refactor, unrelated to what either
+issue asked for, and it expands the diff far beyond a JSON-contract bug
+fix.
+
+### Option C — Fix the producers: they emit a delimiter-neutral value; HTML rendering converts to `<br>` only when building markup (chosen)
+
+## Decision
+
+`RegOptions()`, `SummarizeRoleTypes()`, and `SetGateHosts()` join their
+multi-value output with `|`, not `<br>`. Each HTML call site that
+previously consumed the `<br>`-joined string directly now replaces `|`
+with `<br>` when building the table cell markup; the JSON path captures
+the `|`-delimited value unchanged.
+
+## Rationale
+
+- Matches the issue's own diagnosis: values were "formatted for HTML
+  rendering first... then captured into JSON as-is." Fixing the producer
+  fixes the actual defect, not just its two currently-reported symptoms.
+- `|` keeps the JSON value a plain string (no schema/type change from
+  `string` to `string[]`), so existing consumers parsing these fields as
+  strings are unaffected beyond the delimiter character itself.
+- Covers the third, unreported `SetGateHosts` instance for free, since it
+  shares the same producer-level fix.
+
+## Consequences
+
+### Positive
+
+- The bug class (HTML-formatted value reused verbatim for JSON) is fixed
+  at its source for all three known instances, not patched per-callsite.
+- No change to the `HtmlSection`/`SetSection` contract itself.
+
+### Negative
+
+- HTML call sites for these three values now carry an explicit `|` →
+  `<br>` conversion step that wasn't there before — a future reader of
+  `RegOptions()`/`SummarizeRoleTypes()`/`SetGateHosts()` in isolation will
+  see a `|`-delimited value and need to know it's meant to render as an
+  HTML line-break list.
+- Does not address the six-plus duplicated `SetSection` helpers themselves
+  (see Option B) — a fourth instance of this bug class, in a producer not
+  yet identified, remains possible until that duplication is addressed.
+
+## Validation
+
+None needed beyond compilation and the new xUnit facts covering each of
+the three producers' JSON output (no `<br>` present) and each HTML call
+site (line-break rendering unchanged).

--- a/docs/adr/0029-html-free-values-in-json-export-producers.md
+++ b/docs/adr/0029-html-free-values-in-json-export-producers.md
@@ -89,3 +89,43 @@ the `|`-delimited value unchanged.
 None needed beyond compilation and the new xUnit facts covering each of
 the three producers' JSON output (no `<br>` present) and each HTML call
 site (line-break rendering unchanged).
+
+## Addendum (2026-08-28)
+
+A PR #203 code review found two inaccuracies in this ADR, one of which
+contributed to a real defect shipping in the same PR:
+
+- **"No single choke point" (Option B, above) is wrong.**
+  `CHtmlTables.SetSectionPublic` already existed as a shared internal
+  static helper and was already called by 13+ of the JSON-section call
+  sites at the time this ADR was written. Only ~5 files (including
+  `CRegKeysTable.cs`, `CRepoTable.cs`, and the unreachable
+  `CSobrExtentTable.cs`) duplicate a local private `SetSection` instead
+  of using it. Because this ADR concluded no choke point existed for
+  the HTML-side fix either, the `|` -> `<br>` conversion was hand-applied
+  separately at each call site instead of through one shared helper —
+  and one of those call sites (`CHtmlTables.AddSobrExtTable`, the *live*
+  SOBR Extents renderer) was missed entirely; the fix was applied to
+  `CSobrExtentTable.cs` instead, which has zero instantiation sites
+  anywhere in the repo. A follow-up commit introduced
+  `CGlobals.MultiValueDelimiter` and
+  `CHtmlFormatting.RenderMultiValueHtml` as the shared implementation
+  this ADR should have used from the start, and fixed the missed call
+  site.
+
+- **The Validation section above overclaimed test coverage.** It stated
+  tests covered "each HTML call site (line-break rendering unchanged)",
+  but none of the three new test files exercised any of the four HTML
+  call sites (`AddSobrExtTable`/`AddRequirementsTable` in
+  `CHtmlTables.cs`, `CRegKeysTable`, `CRepoTable`) — only the producers'
+  JSON-side output had coverage. This false confidence plausibly let the
+  missed call site above ship unnoticed. The follow-up commit adds
+  `CHtmlFormattingTEST.cs` (for the new shared helper) and
+  `CRegKeysTableTEST.cs` (HTML-rendering assertions for `CRegKeysTable`).
+  Per this repo's own tooling constraint, these new/changed facts were
+  verified only via `dotnet build` on this (non-Windows) machine —
+  `VhcXTests` compilation is deliberately skipped off-Windows — so they
+  are unverified locally and run for the first time in CI/on Windows.
+
+See [PR #203](https://github.com/VeeamHub/veeam-healthcheck/pull/203)
+for the full review and the fix commits.

--- a/vHC/HC_Reporting/Common/CGlobals.cs
+++ b/vHC/HC_Reporting/Common/CGlobals.cs
@@ -66,6 +66,13 @@ namespace VeeamHealthCheck.Shared
         public static string VHCVERSION = string.Empty;
         public static bool DEBUG = false;
 
+        /// <summary>
+        /// Delimiter multi-value producers (e.g. CDataFormer.RegOptions, SetGateHosts,
+        /// SummarizeRoleTypes) join their values with. HTML rendering converts this to a
+        /// line break at the call site; JSON export keeps it as-is (see ADR 0029).
+        /// </summary>
+        public const string MultiValueDelimiter = "|";
+
         // Remote Exec variables
         public static string VBRServerName = "localhost";
 

--- a/vHC/HC_Reporting/Common/CVersionSetter.cs
+++ b/vHC/HC_Reporting/Common/CVersionSetter.cs
@@ -20,8 +20,8 @@ namespace VeeamHealthCheck.Shared
             }
 
             FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(exePath);
-            CGlobals.VHCVERSION = fvi.FileVersion;
-            return fvi.FileVersion;
+            CGlobals.VHCVERSION = fvi.FileVersion ?? string.Empty;
+            return CGlobals.VHCVERSION;
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/DataTypes/CFullReportJson.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/DataTypes/CFullReportJson.cs
@@ -9,14 +9,14 @@ namespace VeeamHealthCheck.Functions.Reporting.DataTypes
 {
     internal class CFullReportJson
     {
-        public CProtectedWorkloads cProtectedWorkloads { get; set; }
+        // The vHC version that produced this report (CGlobals.VHCVERSION), stamped at export time.
+        public string VhcVersion { get; set; }
+
         public System.Collections.Generic.List<VeeamHealthCheck.Functions.Reporting.DataFormers.OrphanedSupersededBackups.OrphanedSupersededBackupRecord> OrphanedSupersededBackups { get; set; } = new();
         public bool OrphanedBackupsSweepEvaluated { get; set; } = false;
 
         // License data captured from CHtmlTables.LicTable
         public List<License> Licenses { get; set; } = new();
-
-        public string LicenseSummary { get; set; }
 
         // Compliance scan telemetry — populated by CComplianceTable from
         // _SecurityComplianceMeta.csv. Stable contract for VIP ingestion.

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -1010,14 +1010,13 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                 else
                     workingValue = r.Value.ToString();
 
+                if (CRegistrySkipKeys.SkipKeys.Contains(r.Key))
+                {
+                    continue;
+                }
+
                 if (defaults.defaultKeys.TryGetValue(r.Key, out string setValue))
                 {
-                    string[] skipKeys = CRegistrySkipKeys.SkipKeys;
-                    if (skipKeys.Contains(r.Key))
-                    {
-                        continue;
-                    }
-
                     if (setValue != workingValue)
                     {
                         returnDict.Add(r.Key, workingValue);

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -993,17 +993,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
             foreach (var r in RegOptions2)
             {
                 string workingValue = string.Empty;
-                bool isMultiValue = r.Value is string[];
-                if (isMultiValue)
+                bool isMultiValue = false;
+                if (r.Value is string[] valueArray)
                 {
-                    var values = r.Value as IEnumerable;
-                    List<string> valueArray = new();
-                    foreach (var v in values)
-                    {
-                        valueArray.Add(v.ToString());
-                    }
-
                     workingValue = string.Join(CGlobals.MultiValueDelimiter, valueArray);
+                    isMultiValue = valueArray.Length > 1;
                 }
                 else if (r.Value is byte[] byteValue)
                     workingValue = BitConverter.ToString(byteValue).Replace("-", string.Empty);

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -494,11 +494,6 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
         internal string SetGateHosts(string original, bool scrub)
         {
             string[] hosts = original.Split(' ');
-            if (hosts.Count() == 1 && String.IsNullOrEmpty(hosts[0]))
-            {
-                return hosts[0];
-            }
-
             List<string> processed = new();
             foreach (string host in hosts)
             {

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -1000,7 +1000,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                     isMultiValue = valueArray.Length > 1;
                 }
                 else if (r.Value is byte[] byteValue)
-                    workingValue = BitConverter.ToString(byteValue).Replace("-", string.Empty);
+                    workingValue = Convert.ToHexString(byteValue);
                 else
                     workingValue = r.Value.ToString();
 

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -499,9 +499,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                 return hosts[0];
             }
 
-            string r = string.Empty;
-            int counter = 1;
-            int end = hosts.Length;
+            List<string> processed = new();
             foreach (string host in hosts)
             {
                 string newhost = host;
@@ -510,21 +508,10 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                     newhost = CGlobals.Scrubber.ScrubItem(host, ScrubItemType.Server);
                 }
 
-
-                if (counter == end)
-                {
-                    r += newhost + "|";
-                }
-                else
-                {
-                    r += newhost + ",|";
-                }
-
-
-                counter++;
+                processed.Add(newhost);
             }
 
-            return r;
+            return string.Join(CGlobals.MultiValueDelimiter, processed);
         }
 
         public List<CRepository> ExtentXmlFromCsv(bool scrub)

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -1005,6 +1005,8 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
 
                     workingValue = string.Join(CGlobals.MultiValueDelimiter, valueArray);
                 }
+                else if (r.Value is byte[] byteValue)
+                    workingValue = BitConverter.ToString(byteValue).Replace("-", string.Empty);
                 else
                     workingValue = r.Value.ToString();
 

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -967,9 +967,21 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
             return helper.FinalConcurrency(ctList);
         }
 
-        public Dictionary<string, string> RegOptions()
+        public Dictionary<string, string> RegOptions() => this.RegOptions(out _);
+
+        /// <summary>
+        /// Reads the diff between the collected registry keys and their defaults.
+        /// </summary>
+        /// <param name="multiValueKeys">
+        /// Keys whose value was joined from a multi-value (string[]) registry entry using
+        /// <see cref="CGlobals.MultiValueDelimiter"/>. HTML renderers must only convert the
+        /// delimiter to a line break for these keys — a single-value entry may legitimately
+        /// contain a literal "|" character.
+        /// </param>
+        public Dictionary<string, string> RegOptions(out HashSet<string> multiValueKeys)
         {
             Dictionary<string, string> returnDict = new();
+            HashSet<string> multiValues = new();
 
             var reg = new CCsvParser();
 
@@ -981,7 +993,8 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
             foreach (var r in RegOptions2)
             {
                 string workingValue = string.Empty;
-                if (r.Value.GetType() == typeof(string[]))
+                bool isMultiValue = r.Value is string[];
+                if (isMultiValue)
                 {
                     var values = r.Value as IEnumerable;
                     List<string> valueArray = new();
@@ -1008,6 +1021,10 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                     if (setValue != workingValue)
                     {
                         returnDict.Add(r.Key, workingValue);
+                        if (isMultiValue)
+                        {
+                            multiValues.Add(r.Key);
+                        }
                     }
                 }
 
@@ -1015,9 +1032,14 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                 {
                     defaults.defaultKeys.TryGetValue(r.Key, out string setValue);
                     returnDict.Add(r.Key, workingValue);
+                    if (isMultiValue)
+                    {
+                        multiValues.Add(r.Key);
+                    }
                 }
             }
 
+            multiValueKeys = multiValues;
             return returnDict;
         }
 

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -1003,7 +1003,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                         valueArray.Add(v.ToString());
                     }
 
-                    workingValue = string.Join("|", valueArray);
+                    workingValue = string.Join(CGlobals.MultiValueDelimiter, valueArray);
                 }
                 else
                     workingValue = r.Value.ToString();
@@ -1133,7 +1133,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                                   .Select(g => g.Count() > 1 ? $"{g.Key} ×{g.Count()}" : g.Key);
 
             // Join with a plain delimiter; HTML call sites convert to <br> for display (issue #171)
-            return string.Join("|", typeCounts);
+            return string.Join(CGlobals.MultiValueDelimiter, typeCounts);
         }
 
         /// <summary>

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -1010,7 +1010,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                 else
                     workingValue = r.Value.ToString();
 
-                if (defaults.defaultKeys.ContainsKey(r.Key))
+                if (defaults.defaultKeys.TryGetValue(r.Key, out string setValue))
                 {
                     string[] skipKeys = CRegistrySkipKeys.SkipKeys;
                     if (skipKeys.Contains(r.Key))
@@ -1018,8 +1018,6 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                         continue;
                     }
 
-
-                    defaults.defaultKeys.TryGetValue(r.Key, out string setValue);
                     if (setValue != workingValue)
                     {
                         returnDict.Add(r.Key, workingValue);
@@ -1029,10 +1027,8 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                         }
                     }
                 }
-
-                if (!defaults.defaultKeys.ContainsKey(r.Key))
+                else
                 {
-                    defaults.defaultKeys.TryGetValue(r.Key, out string setValue);
                     returnDict.Add(r.Key, workingValue);
                     if (isMultiValue)
                     {

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CDataFormer.cs
@@ -491,7 +491,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
             return outList;
         }
 
-        private string SetGateHosts(string original, bool scrub)
+        internal string SetGateHosts(string original, bool scrub)
         {
             string[] hosts = original.Split(' ');
             if (hosts.Count() == 1 && String.IsNullOrEmpty(hosts[0]))
@@ -513,11 +513,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
 
                 if (counter == end)
                 {
-                    r += newhost + "<br>";
+                    r += newhost + "|";
                 }
                 else
                 {
-                    r += newhost + ",<br>";
+                    r += newhost + ",|";
                 }
 
 
@@ -1003,7 +1003,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                         valueArray.Add(v.ToString());
                     }
 
-                    workingValue = string.Join("<br>", valueArray);
+                    workingValue = string.Join("|", valueArray);
                 }
                 else
                     workingValue = r.Value.ToString();
@@ -1106,9 +1106,9 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
 
         /// <summary>
         /// Summarizes repeated role types into a count format with friendly names.
-        /// Example: "Gateway/ Gateway/ Gateway/ Repository/ Gateway" becomes "Gateway Server ×4<br>Repository ×1"
+        /// Example: "Gateway/ Gateway/ Gateway/ Repository/ Gateway" becomes "Gateway Server ×4|Repository ×1"
         /// </summary>
-        private string SummarizeRoleTypes(string typeString)
+        internal string SummarizeRoleTypes(string typeString)
         {
             if (string.IsNullOrWhiteSpace(typeString))
                 return typeString;
@@ -1132,8 +1132,8 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                                   .ThenBy(g => g.Key)
                                   .Select(g => g.Count() > 1 ? $"{g.Key} ×{g.Count()}" : g.Key);
 
-            // Join with HTML line breaks for vertical display
-            return string.Join("<br>", typeCounts);
+            // Join with a plain delimiter; HTML call sites convert to <br> for display (issue #171)
+            return string.Join("|", typeCounts);
         }
 
         /// <summary>

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CHtmlExporter.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CHtmlExporter.cs
@@ -239,6 +239,8 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                 string jsonPath = this.latestReport.Replace(".html", ".json");
                 this.log.Info("Exporting JSON report to: " + jsonPath);
 
+                CGlobals.FullReportJson.VhcVersion = CGlobals.VHCVERSION;
+
                 var options = new JsonSerializerOptions { WriteIndented = true };
                 string json = JsonSerializer.Serialize(CGlobals.FullReportJson, options);
                 File.WriteAllText(jsonPath, json);

--- a/vHC/HC_Reporting/Functions/Reporting/Html/Shared/CHtmlFormatting.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/Shared/CHtmlFormatting.cs
@@ -204,6 +204,15 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.Shared
             return $"<td{titleAttr}>{data}</td>";
         }
 
+        /// <summary>
+        /// Converts a producer's <see cref="CGlobals.MultiValueDelimiter"/>-joined value into
+        /// HTML line breaks for table rendering. JSON export keeps the delimiter unchanged.
+        /// </summary>
+        public string RenderMultiValueHtml(string value)
+        {
+            return value?.Replace(CGlobals.MultiValueDelimiter, "<br>");
+        }
+
         public string TableData(string data, string toolTip, int shading)
         {
             string cssClass = shading switch

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
@@ -953,12 +953,15 @@ namespace VeeamHealthCheck.Html.VBR
             s += this.form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrExt15TT);
             s += this.form.TableHeaderEnd();
             s += this.form.TableBodyStart();
+            List<CRepository> list = new();
+            bool fetched = false;
             try
             {
                 this.log.Info("Attempting to load SOBR Extent data...");
-                List<CRepository> list = this.df.ExtentXmlFromCsv(scrub);
+                list = this.df.ExtentXmlFromCsv(scrub) ?? new List<CRepository>();
+                fetched = true;
 
-                if (list == null || list.Count == 0)
+                if (list.Count == 0)
                 {
                     this.log.Warning("No SOBR Extent data found. The SOBRExtents CSV file may be missing or empty.");
                     this.log.Info("This could indicate: 1) No SOBRs configured, 2) Collection script failed, or 3) CSV file not found");
@@ -1051,34 +1054,36 @@ namespace VeeamHealthCheck.Html.VBR
             s += this.form.SectionEnd(summary);
 
             // JSON extents
-            try
+            if (fetched)
             {
-                var list = this.df.ExtentXmlFromCsv(scrub) ?? new List<CRepository>();
-                List<string> headers = new() { "Name", "SobrName", "MaxTasks", "Cores", "Ram", "IsAutoGate", "Host", "Path", "FreeSpace", "TotalSpace", "FreeSpacePercent", "IsDecompress", "AlignBlocks", "IsRotatedDrives", "IsImmutabilitySupported", "Type" };
-                List<List<string>> rows = list.Select(d => new List<string>
+                try
                 {
-                    d.Name,
-                    d.SobrName,
-                    d.MaxTasks.ToString(),
-                    d.Cores.ToString(),
-                    d.Ram.ToString(),
-                    d.IsAutoGate ? "True" : "False",
-                    d.Host,
-                    d.Path,
-                    d.FreeSpace.ToString(),
-                    d.TotalSpace.ToString(),
-                    d.FreeSpacePercent.ToString(),
-                    d.IsDecompress ? "True" : "False",
-                    d.AlignBlocks ? "True" : "False",
-                    d.IsRotatedDrives ? "True" : "False",
-                    d.IsImmutabilitySupported ? "True" : "False",
-                    d.Type,
-                }).ToList();
-                SetSection("extents", headers, rows, summary);
-            }
-            catch (Exception ex)
-            {
-                this.log.Error("Failed to capture extents JSON section: " + ex.Message);
+                    List<string> headers = new() { "Name", "SobrName", "MaxTasks", "Cores", "Ram", "IsAutoGate", "Host", "Path", "FreeSpace", "TotalSpace", "FreeSpacePercent", "IsDecompress", "AlignBlocks", "IsRotatedDrives", "IsImmutabilitySupported", "Type" };
+                    List<List<string>> rows = list.Select(d => new List<string>
+                    {
+                        d.Name,
+                        d.SobrName,
+                        d.MaxTasks.ToString(),
+                        d.Cores.ToString(),
+                        d.Ram.ToString(),
+                        d.IsAutoGate ? "True" : "False",
+                        d.Host,
+                        d.Path,
+                        d.FreeSpace.ToString(),
+                        d.TotalSpace.ToString(),
+                        d.FreeSpacePercent.ToString(),
+                        d.IsDecompress ? "True" : "False",
+                        d.AlignBlocks ? "True" : "False",
+                        d.IsRotatedDrives ? "True" : "False",
+                        d.IsImmutabilitySupported ? "True" : "False",
+                        d.Type,
+                    }).ToList();
+                    SetSection("extents", headers, rows, summary);
+                }
+                catch (Exception ex)
+                {
+                    this.log.Error("Failed to capture extents JSON section: " + ex.Message);
+                }
             }
 
             return s;

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
@@ -994,7 +994,7 @@ namespace VeeamHealthCheck.Html.VBR
                         s += this.form.TableData(this.form.False, string.Empty);
                     }
 
-                    s += this.form.TableData(d.Host, string.Empty);
+                    s += this.form.TableData(d.Host?.Replace("|", "<br>"), string.Empty);
                     s += this.form.TableData(d.Path, string.Empty);
                     s += this.form.TableData(d.FreeSpace.ToString(), string.Empty);
                     s += this.form.TableData(d.TotalSpace.ToString(), string.Empty);

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
@@ -1338,7 +1338,7 @@ namespace VeeamHealthCheck.Html.VBR
 
                         s += "<tr>";
                         s += this.form.TableData(server, string.Empty);
-                        s += this.form.TableData(r[1], string.Empty);
+                        s += this.form.TableData(r[1]?.Replace("|", "<br>"), string.Empty);
 
                         if (reqCoresWarn)
                         {

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/CHtmlTables.cs
@@ -994,7 +994,7 @@ namespace VeeamHealthCheck.Html.VBR
                         s += this.form.TableData(this.form.False, string.Empty);
                     }
 
-                    s += this.form.TableData(d.Host?.Replace("|", "<br>"), string.Empty);
+                    s += this.form.TableData(this.form.RenderMultiValueHtml(d.Host), string.Empty);
                     s += this.form.TableData(d.Path, string.Empty);
                     s += this.form.TableData(d.FreeSpace.ToString(), string.Empty);
                     s += this.form.TableData(d.TotalSpace.ToString(), string.Empty);
@@ -1338,7 +1338,7 @@ namespace VeeamHealthCheck.Html.VBR
 
                         s += "<tr>";
                         s += this.form.TableData(server, string.Empty);
-                        s += this.form.TableData(r[1]?.Replace("|", "<br>"), string.Empty);
+                        s += this.form.TableData(this.form.RenderMultiValueHtml(r[1]), string.Empty);
 
                         if (reqCoresWarn)
                         {

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Managed Server Table/CManagedServerTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Managed Server Table/CManagedServerTable.cs
@@ -7,6 +7,7 @@ using VeeamHealthCheck.Functions.Reporting.DataTypes;
 using VeeamHealthCheck.Functions.Reporting.Html.DataFormers;
 using VeeamHealthCheck.Functions.Reporting.Html.Shared;
 using VeeamHealthCheck.Functions.Reporting.Html.VBR;
+using VeeamHealthCheck.Html.VBR;
 using VeeamHealthCheck.Reporting.Html.VBR;
 using VeeamHealthCheck.Resources.Localization;
 using VeeamHealthCheck.Shared;
@@ -129,7 +130,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Managed_Server
                     d.IsUnavailable.ToString(),
                     d.Platform ?? "",
                 }).ToList();
-                SetSection("managedServers", headers, rows, summary);
+                CHtmlTables.SetSectionPublic("managedServers", headers, rows, summary);
             }
             catch (Exception ex)
             {
@@ -137,21 +138,6 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Managed_Server
             }
 
             return s;
-        }
-
-        private static void SetSection(string key, List<string> headers, List<List<string>> rows, string summary)
-        {
-            if (CGlobals.FullReportJson == null)
-            {
-                CGlobals.FullReportJson = new();
-            }
-
-            CGlobals.FullReportJson.Sections[key] = new HtmlSection
-            {
-                SectionName = key,
-                Headers = headers,
-                Rows = rows,
-            };
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Proxies/CProxyTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Proxies/CProxyTable.cs
@@ -7,6 +7,7 @@ using VeeamHealthCheck.Functions.Reporting.DataTypes;
 using VeeamHealthCheck.Functions.Reporting.Html.DataFormers;
 using VeeamHealthCheck.Functions.Reporting.Html.Shared;
 using VeeamHealthCheck.Functions.Reporting.Html.VBR;
+using VeeamHealthCheck.Html.VBR;
 using VeeamHealthCheck.Resources.Localization;
 using VeeamHealthCheck.Scrubber;
 using VeeamHealthCheck.Shared;
@@ -137,7 +138,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Proxies
                 {
                     d[0], d[1], d[2], d[3], d[4], d[6], d[7], d[8], d[9], d[10], d[11],
                 }).ToList();
-                SetSection("proxies", headers, rows, summary);
+                CHtmlTables.SetSectionPublic("proxies", headers, rows, summary);
             }
             catch (Exception ex)
             {
@@ -145,21 +146,6 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Proxies
             }
 
             return s;
-        }
-
-        private static void SetSection(string key, List<string> headers, List<List<string>> rows, string summary)
-        {
-            if (CGlobals.FullReportJson == null)
-            {
-                CGlobals.FullReportJson = new();
-            }
-
-            CGlobals.FullReportJson.Sections[key] = new HtmlSection
-            {
-                SectionName = key,
-                Headers = headers,
-                Rows = rows,
-            };
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTable.cs
@@ -60,7 +60,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Registry
                     {
                         s += "<tr>";
                         s += form.TableData(d.Key, string.Empty);
-                        s += form.TableData(d.Value.ToString(), string.Empty);
+                        s += form.TableData(d.Value.ToString().Replace("|", "<br>"), string.Empty);
                         s += "</tr>";
                     }
                 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTable.cs
@@ -7,6 +7,7 @@ using VeeamHealthCheck.Functions.Reporting.DataTypes;
 using VeeamHealthCheck.Functions.Reporting.Html.DataFormers;
 using VeeamHealthCheck.Functions.Reporting.Html.Shared;
 using VeeamHealthCheck.Functions.Reporting.Html.VBR;
+using VeeamHealthCheck.Html.VBR;
 using VeeamHealthCheck.Resources.Localization;
 using VeeamHealthCheck.Shared;
 using VeeamHealthCheck.Shared.Logging;
@@ -84,7 +85,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Registry
                 {
                     List<string> headers = new() { "Key", "Value" };
                     List<List<string>> rows = list.Select(kv => new List<string> { kv.Key, kv.Value }).ToList();
-                    SetSection("regKeys", headers, rows, summary);
+                    CHtmlTables.SetSectionPublic("regKeys", headers, rows, summary);
                 }
                 catch (Exception ex)
                 {
@@ -93,21 +94,6 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Registry
             }
 
             return s;
-        }
-
-        private static void SetSection(string key, List<string> headers, List<List<string>> rows, string summary)
-        {
-            if (CGlobals.FullReportJson == null)
-            {
-                CGlobals.FullReportJson = new();
-            }
-
-            CGlobals.FullReportJson.Sections[key] = new HtmlSection
-            {
-                SectionName = key,
-                Headers = headers,
-                Rows = rows,
-            };
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTable.cs
@@ -33,7 +33,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Registry
 
             try
             {
-                Dictionary<string, string> list = df.RegOptions();
+                Dictionary<string, string> list = df.RegOptions(out HashSet<string> multiValueKeys);
                 if (list.Count == 0)
                 {
                     s += form.TableHeader(VbrLocalizationHelper.Reg0, VbrLocalizationHelper.Reg0TT);
@@ -60,7 +60,10 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Registry
                     {
                         s += "<tr>";
                         s += form.TableData(d.Key, string.Empty);
-                        s += form.TableData(d.Value.ToString().Replace("|", "<br>"), string.Empty);
+                        string displayValue = multiValueKeys.Contains(d.Key)
+                            ? form.RenderMultiValueHtml(d.Value)
+                            : d.Value;
+                        s += form.TableData(displayValue, string.Empty);
                         s += "</tr>";
                     }
                 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTable.cs
@@ -31,9 +31,10 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Registry
             string s = form.SectionStartWithButton("regkeys", VbrLocalizationHelper.RegTitle, VbrLocalizationHelper.RegBtn);
             string summary = sum.RegKeys();
 
+            Dictionary<string, string> list = null;
             try
             {
-                Dictionary<string, string> list = df.RegOptions(out HashSet<string> multiValueKeys);
+                list = df.RegOptions(out HashSet<string> multiValueKeys);
                 if (list.Count == 0)
                 {
                     s += form.TableHeader(VbrLocalizationHelper.Reg0, VbrLocalizationHelper.Reg0TT);
@@ -77,16 +78,18 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Registry
             s += form.SectionEnd(summary);
 
             // JSON reg keys
-            try
+            if (list != null)
             {
-                var list = df.RegOptions();
-                List<string> headers = new() { "Key", "Value" };
-                List<List<string>> rows = list.Select(kv => new List<string> { kv.Key, kv.Value }).ToList();
-                SetSection("regKeys", headers, rows, summary);
-            }
-            catch (Exception ex)
-            {
-                log.Error("Failed to capture regKeys JSON section: " + ex.Message);
+                try
+                {
+                    List<string> headers = new() { "Key", "Value" };
+                    List<List<string>> rows = list.Select(kv => new List<string> { kv.Key, kv.Value }).ToList();
+                    SetSection("regKeys", headers, rows, summary);
+                }
+                catch (Exception ex)
+                {
+                    log.Error("Failed to capture regKeys JSON section: " + ex.Message);
+                }
             }
 
             return s;

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
@@ -84,7 +84,7 @@ form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrExt15T
                         s += form.TableData(form.False, string.Empty);
                     }
 
-                    s += form.TableData(d.Host?.Replace("|", "<br>"), string.Empty);
+                    s += form.TableData(form.RenderMultiValueHtml(d.Host), string.Empty);
                     s += form.TableData(d.Path, string.Empty);
                     s += form.TableData(d.FreeSpace.ToString(), string.Empty);
                     s += form.TableData(d.TotalSpace.ToString(), string.Empty);

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
@@ -51,9 +51,10 @@ form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrExt15T
 
             s += form.TableHeaderEnd();
             s += form.TableBodyStart();
+            List<CRepository> list = new();
             try
             {
-                List<CRepository> list = df.RepoInfoToXml(scrub);
+                list = df.RepoInfoToXml(scrub) ?? new List<CRepository>();
 
                 foreach (var d in list)
                 {
@@ -150,7 +151,6 @@ form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrExt15T
             // JSON repos
             try
             {
-                var list = df.RepoInfoToXml(scrub) ?? new List<CRepository>();
                 List<string> headers = new() { "Name", "JobCount", "MaxTasks", "Cores", "Ram", "IsAutoGate", "Host", "Path", "FreeSpace", "TotalSpace", "FreeSpacePercent", "IsPerVmBackupFiles", "IsDecompress", "AlignBlocks", "IsRotatedDrives", "IsImmutabilitySupported", "Type" };
                 List<List<string>> rows = list.Select(d => new List<string>
                 {

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
@@ -7,6 +7,7 @@ using VeeamHealthCheck.Functions.Reporting.DataTypes;
 using VeeamHealthCheck.Functions.Reporting.Html.DataFormers;
 using VeeamHealthCheck.Functions.Reporting.Html.Shared;
 using VeeamHealthCheck.Functions.Reporting.Html.VBR;
+using VeeamHealthCheck.Html.VBR;
 using VeeamHealthCheck.Resources.Localization;
 using VeeamHealthCheck.Shared;
 using VeeamHealthCheck.Shared.Logging;
@@ -176,7 +177,7 @@ form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrExt15T
                         d.IsImmutabilitySupported ? "True" : "False",
                         d.Type,
                     }).ToList();
-                    SetSection("repos", headers, rows, summary);
+                    CHtmlTables.SetSectionPublic("repos", headers, rows, summary);
                 }
                 catch (Exception ex)
                 {
@@ -194,21 +195,6 @@ form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrExt15T
                               : usedPercent >= 60 ? "progress-warning"
                               : "progress-ok";
             return $@"<td><div class=""progress-bar""><div class=""progress-track""><div class=""progress-fill {colorClass}"" style=""width:{usedPercent:F0}%""></div></div><div class=""progress-label"">{freePercent:F0}% free</div></div></td>";
-        }
-
-        private static void SetSection(string key, List<string> headers, List<List<string>> rows, string summary)
-        {
-            if (CGlobals.FullReportJson == null)
-            {
-                CGlobals.FullReportJson = new();
-            }
-
-            CGlobals.FullReportJson.Sections[key] = new HtmlSection
-            {
-                SectionName = key,
-                Headers = headers,
-                Rows = rows,
-            };
         }
     }
 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
@@ -84,7 +84,7 @@ form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrExt15T
                         s += form.TableData(form.False, string.Empty);
                     }
 
-                    s += form.TableData(d.Host, string.Empty);
+                    s += form.TableData(d.Host?.Replace("|", "<br>"), string.Empty);
                     s += form.TableData(d.Path, string.Empty);
                     s += form.TableData(d.FreeSpace.ToString(), string.Empty);
                     s += form.TableData(d.TotalSpace.ToString(), string.Empty);

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Repositories/CRepoTable.cs
@@ -52,9 +52,11 @@ form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrExt15T
             s += form.TableHeaderEnd();
             s += form.TableBodyStart();
             List<CRepository> list = new();
+            bool fetched = false;
             try
             {
                 list = df.RepoInfoToXml(scrub) ?? new List<CRepository>();
+                fetched = true;
 
                 foreach (var d in list)
                 {
@@ -149,34 +151,37 @@ form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrExt15T
             s += form.SectionEnd(summary);
 
             // JSON repos
-            try
+            if (fetched)
             {
-                List<string> headers = new() { "Name", "JobCount", "MaxTasks", "Cores", "Ram", "IsAutoGate", "Host", "Path", "FreeSpace", "TotalSpace", "FreeSpacePercent", "IsPerVmBackupFiles", "IsDecompress", "AlignBlocks", "IsRotatedDrives", "IsImmutabilitySupported", "Type" };
-                List<List<string>> rows = list.Select(d => new List<string>
+                try
                 {
-                    d.Name,
-                    d.JobCount.ToString(),
-                    d.MaxTasks.ToString(),
-                    d.Cores.ToString(),
-                    d.Ram.ToString(),
-                    d.IsAutoGate ? "True" : "False",
-                    d.Host,
-                    d.Path,
-                    d.FreeSpace.ToString(),
-                    d.TotalSpace.ToString(),
-                    d.FreeSpacePercent.ToString(),
-                    d.IsPerVmBackupFiles ? "True" : "False",
-                    d.IsDecompress ? "True" : "False",
-                    d.AlignBlocks ? "True" : "False",
-                    d.IsRotatedDrives ? "True" : "False",
-                    d.IsImmutabilitySupported ? "True" : "False",
-                    d.Type,
-                }).ToList();
-                SetSection("repos", headers, rows, summary);
-            }
-            catch (Exception ex)
-            {
-                log.Error("Failed to capture repos JSON section: " + ex.Message);
+                    List<string> headers = new() { "Name", "JobCount", "MaxTasks", "Cores", "Ram", "IsAutoGate", "Host", "Path", "FreeSpace", "TotalSpace", "FreeSpacePercent", "IsPerVmBackupFiles", "IsDecompress", "AlignBlocks", "IsRotatedDrives", "IsImmutabilitySupported", "Type" };
+                    List<List<string>> rows = list.Select(d => new List<string>
+                    {
+                        d.Name,
+                        d.JobCount.ToString(),
+                        d.MaxTasks.ToString(),
+                        d.Cores.ToString(),
+                        d.Ram.ToString(),
+                        d.IsAutoGate ? "True" : "False",
+                        d.Host,
+                        d.Path,
+                        d.FreeSpace.ToString(),
+                        d.TotalSpace.ToString(),
+                        d.FreeSpacePercent.ToString(),
+                        d.IsPerVmBackupFiles ? "True" : "False",
+                        d.IsDecompress ? "True" : "False",
+                        d.AlignBlocks ? "True" : "False",
+                        d.IsRotatedDrives ? "True" : "False",
+                        d.IsImmutabilitySupported ? "True" : "False",
+                        d.Type,
+                    }).ToList();
+                    SetSection("repos", headers, rows, summary);
+                }
+                catch (Exception ex)
+                {
+                    log.Error("Failed to capture repos JSON section: " + ex.Message);
+                }
             }
 
             return s;

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/SOBR/CSobrExtentTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/SOBR/CSobrExtentTable.cs
@@ -80,7 +80,7 @@ this.form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrE
 
                     s += this.BoolCell(d.IsAutoGate);
 
-                    s += this.form.TableData(d.Host, string.Empty);
+                    s += this.form.TableData(d.Host?.Replace("|", "<br>"), string.Empty);
                     s += this.form.TableData(d.Path, string.Empty);
                     s += this.form.TableData(d.FreeSpace.ToString(), string.Empty);
                     s += this.form.TableData(d.TotalSpace.ToString(), string.Empty);

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/SOBR/CSobrExtentTable.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/SOBR/CSobrExtentTable.cs
@@ -80,7 +80,7 @@ this.form.TableHeader(VbrLocalizationHelper.SbrExt15, VbrLocalizationHelper.SbrE
 
                     s += this.BoolCell(d.IsAutoGate);
 
-                    s += this.form.TableData(d.Host?.Replace("|", "<br>"), string.Empty);
+                    s += this.form.TableData(this.form.RenderMultiValueHtml(d.Host), string.Empty);
                     s += this.form.TableData(d.Path, string.Empty);
                     s += this.form.TableData(d.FreeSpace.ToString(), string.Empty);
                     s += this.form.TableData(d.TotalSpace.ToString(), string.Empty);

--- a/vHC/VhcXTests/Functions/Reporting/DataTypes/CFullReportJsonTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/DataTypes/CFullReportJsonTEST.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using VeeamHealthCheck.Functions.Reporting.DataTypes;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.DataTypes
+{
+    /// <summary>
+    /// Tests for the CFullReportJson top-level JSON export contract.
+    /// Covers issue #172 (dead null fields removed) and the VhcVersion field.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class CFullReportJsonTEST
+    {
+        [Fact]
+        public void Serialize_DefaultInstance_DoesNotContainLegacyNullFields()
+        {
+            // Arrange
+            var report = new CFullReportJson();
+
+            // Act
+            string json = JsonSerializer.Serialize(report);
+
+            // Assert: issue #172 - cProtectedWorkloads and LicenseSummary were always
+            // null and have been removed from the contract entirely, not just left null.
+            Assert.DoesNotContain("cProtectedWorkloads", json);
+            Assert.DoesNotContain("LicenseSummary", json);
+        }
+
+        [Fact]
+        public void VhcVersion_Serialized_RoundTripsThroughJson()
+        {
+            // Arrange
+            var report = new CFullReportJson { VhcVersion = "3.0.1.169" };
+
+            // Act
+            string json = JsonSerializer.Serialize(report);
+            var roundTripped = JsonSerializer.Deserialize<CFullReportJson>(json);
+
+            // Assert
+            Assert.Contains("\"VhcVersion\":\"3.0.1.169\"", json);
+            Assert.Equal("3.0.1.169", roundTripped.VhcVersion);
+        }
+    }
+}

--- a/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
@@ -71,6 +71,33 @@ namespace VhcXTests.Functions.Reporting.Html
         }
 
         [Fact]
+        public void RegOptions_BinaryRegistryValue_RendersHexNotTypeName()
+        {
+            // Arrange
+            var originalKeys = CGlobals.DEFAULTREGISTRYKEYS;
+            CGlobals.DEFAULTREGISTRYKEYS = new Dictionary<string, object>
+            {
+                ["VhcTest_BinaryKey"] = new byte[] { 0x01, 0x02, 0xAB },
+            };
+
+            try
+            {
+                var df = new CDataFormer();
+
+                // Act
+                Dictionary<string, string> result = df.RegOptions();
+
+                // Assert
+                Assert.Equal("0102AB", result["VhcTest_BinaryKey"]);
+                Assert.DoesNotContain("Byte[]", result["VhcTest_BinaryKey"]);
+            }
+            finally
+            {
+                CGlobals.DEFAULTREGISTRYKEYS = originalKeys;
+            }
+        }
+
+        [Fact]
         public void SummarizeRoleTypes_MultipleRoles_JoinsWithPipeNotHtmlBreak()
         {
             // Arrange

--- a/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using VeeamHealthCheck;
 using VeeamHealthCheck.Functions.Reporting.Html;
+using VeeamHealthCheck.Shared;
 using Xunit;
 
 namespace VhcXTests.Functions.Reporting.Html

--- a/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
@@ -42,6 +42,35 @@ namespace VhcXTests.Functions.Reporting.Html
         }
 
         [Fact]
+        public void RegOptions_WithMultiValueKeyFlag_OnlyFlagsTheMultiValueEntry()
+        {
+            // Arrange
+            var originalKeys = CGlobals.DEFAULTREGISTRYKEYS;
+            CGlobals.DEFAULTREGISTRYKEYS = new Dictionary<string, object>
+            {
+                ["VhcTest_MultiValueKey"] = new[] { "austriaeast", "brazilsoutheast" },
+                ["VhcTest_SingleValueKey"] = "C:\\Path|WithLiteralPipe",
+            };
+
+            try
+            {
+                var df = new CDataFormer();
+
+                // Act
+                Dictionary<string, string> result = df.RegOptions(out HashSet<string> multiValueKeys);
+
+                // Assert
+                Assert.Contains("VhcTest_MultiValueKey", multiValueKeys);
+                Assert.DoesNotContain("VhcTest_SingleValueKey", multiValueKeys);
+                Assert.Equal("C:\\Path|WithLiteralPipe", result["VhcTest_SingleValueKey"]);
+            }
+            finally
+            {
+                CGlobals.DEFAULTREGISTRYKEYS = originalKeys;
+            }
+        }
+
+        [Fact]
         public void SummarizeRoleTypes_MultipleRoles_JoinsWithPipeNotHtmlBreak()
         {
             // Arrange

--- a/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using VeeamHealthCheck;
+using VeeamHealthCheck.Functions.Reporting.Html;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.Html
+{
+    /// <summary>
+    /// Tests for issue #171: JSON export must not leak HTML markup.
+    /// CDataFormer's multi-value producers must join with a plain delimiter (|),
+    /// not the HTML "&lt;br&gt;" separator that used to be captured verbatim into JSON.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Collection("GlobalState")]
+    public class CDataFormerJsonDelimiterTEST
+    {
+        [Fact]
+        public void RegOptions_MultiValueRegistryKey_JoinsWithPipeNotHtmlBreak()
+        {
+            // Arrange
+            var originalKeys = CGlobals.DEFAULTREGISTRYKEYS;
+            CGlobals.DEFAULTREGISTRYKEYS = new Dictionary<string, object>
+            {
+                ["VhcTest_MultiValueKey"] = new[] { "austriaeast", "brazilsoutheast" },
+            };
+
+            try
+            {
+                var df = new CDataFormer();
+
+                // Act
+                Dictionary<string, string> result = df.RegOptions();
+
+                // Assert
+                Assert.Equal("austriaeast|brazilsoutheast", result["VhcTest_MultiValueKey"]);
+                Assert.DoesNotContain("<br>", result["VhcTest_MultiValueKey"]);
+            }
+            finally
+            {
+                CGlobals.DEFAULTREGISTRYKEYS = originalKeys;
+            }
+        }
+
+        [Fact]
+        public void SummarizeRoleTypes_MultipleRoles_JoinsWithPipeNotHtmlBreak()
+        {
+            // Arrange
+            var df = new CDataFormer();
+
+            // Act
+            string result = df.SummarizeRoleTypes("Gateway/ Gateway/ Gateway/ Repository/ Gateway");
+
+            // Assert
+            Assert.DoesNotContain("<br>", result);
+            Assert.Contains("|", result);
+        }
+
+        [Fact]
+        public void SetGateHosts_MultipleHosts_JoinsWithPipeNotHtmlBreak()
+        {
+            // Arrange
+            var df = new CDataFormer();
+
+            // Act
+            string result = df.SetGateHosts("gateway1 gateway2", false);
+
+            // Assert
+            Assert.Equal("gateway1,|gateway2|", result);
+            Assert.DoesNotContain("<br>", result);
+        }
+    }
+}

--- a/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/CDataFormerJsonDelimiterTEST.cs
@@ -65,8 +65,34 @@ namespace VhcXTests.Functions.Reporting.Html
             string result = df.SetGateHosts("gateway1 gateway2", false);
 
             // Assert
-            Assert.Equal("gateway1,|gateway2|", result);
+            Assert.Equal("gateway1|gateway2", result);
             Assert.DoesNotContain("<br>", result);
+        }
+
+        [Fact]
+        public void SetGateHosts_SingleHost_NoTrailingDelimiter()
+        {
+            // Arrange
+            var df = new CDataFormer();
+
+            // Act
+            string result = df.SetGateHosts("gateway1", false);
+
+            // Assert
+            Assert.Equal("gateway1", result);
+        }
+
+        [Fact]
+        public void SetGateHosts_EmptyString_ReturnsEmpty()
+        {
+            // Arrange
+            var df = new CDataFormer();
+
+            // Act
+            string result = df.SetGateHosts(string.Empty, false);
+
+            // Assert
+            Assert.Equal(string.Empty, result);
         }
     }
 }

--- a/vHC/VhcXTests/Functions/Reporting/Html/CHtmlExporterTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/CHtmlExporterTEST.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using VeeamHealthCheck;
 using VeeamHealthCheck.Functions.Reporting.Html;
 using VeeamHealthCheck.Shared;
@@ -215,6 +216,46 @@ namespace VhcXTests.Functions.Reporting.Html
                 CGlobals.OpenHtml = originalOpenHtml;
                 CGlobals.EXPORTPDF = originalExportPdf;
                 CGlobals.EXPORTPPTX = originalExportPptx;
+            }
+        }
+
+        [Fact]
+        public void ExportVbrHtml_ValidHtml_JsonReportIncludesVhcVersion()
+        {
+            // Arrange
+            var exporter = new CHtmlExporter("TestServer");
+            var testHtml = "<html><head><title>Test</title></head><body>Test content</body></html>";
+
+            bool originalOpenHtml = CGlobals.OpenHtml;
+            bool originalExportPdf = CGlobals.EXPORTPDF;
+            bool originalExportPptx = CGlobals.EXPORTPPTX;
+            string originalVersion = CGlobals.VHCVERSION;
+            var originalFullReportJson = CGlobals.FullReportJson;
+
+            CGlobals.OpenHtml = false;
+            CGlobals.EXPORTPDF = false;
+            CGlobals.EXPORTPPTX = false;
+            CGlobals.VHCVERSION = "9.9.9.9";
+            CGlobals.FullReportJson = new VeeamHealthCheck.Functions.Reporting.DataTypes.CFullReportJson();
+
+            try
+            {
+                // Act
+                exporter.ExportVbrHtml(testHtml, false);
+
+                // Assert
+                var origDir = Path.Combine(_testOutputDir, CVariables.unsafeSuffix.TrimStart('\\'));
+                var jsonFile = Directory.GetFiles(origDir, "*.json").Single();
+                var json = File.ReadAllText(jsonFile);
+                Assert.Contains("\"VhcVersion\": \"9.9.9.9\"", json);
+            }
+            finally
+            {
+                CGlobals.OpenHtml = originalOpenHtml;
+                CGlobals.EXPORTPDF = originalExportPdf;
+                CGlobals.EXPORTPPTX = originalExportPptx;
+                CGlobals.VHCVERSION = originalVersion;
+                CGlobals.FullReportJson = originalFullReportJson;
             }
         }
 

--- a/vHC/VhcXTests/Functions/Reporting/Html/Shared/CHtmlFormattingTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/Shared/CHtmlFormattingTEST.cs
@@ -1,0 +1,53 @@
+using VeeamHealthCheck.Functions.Reporting.Html.Shared;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.Html.Shared
+{
+    /// <summary>
+    /// Tests for CHtmlFormatting.RenderMultiValueHtml, the shared HTML call-site
+    /// helper introduced to fix the issue #171 HTML-leak bug class (ADR 0029).
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class CHtmlFormattingTEST
+    {
+        [Fact]
+        public void RenderMultiValueHtml_PipeDelimitedValue_ConvertsToLineBreaks()
+        {
+            var form = new CHtmlFormatting();
+
+            string result = form.RenderMultiValueHtml("gateway1|gateway2");
+
+            Assert.Equal("gateway1<br>gateway2", result);
+        }
+
+        [Fact]
+        public void RenderMultiValueHtml_NoDelimiter_ReturnsValueUnchanged()
+        {
+            var form = new CHtmlFormatting();
+
+            string result = form.RenderMultiValueHtml("singlehost");
+
+            Assert.Equal("singlehost", result);
+        }
+
+        [Fact]
+        public void RenderMultiValueHtml_Null_ReturnsNull()
+        {
+            var form = new CHtmlFormatting();
+
+            string result = form.RenderMultiValueHtml(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void RenderMultiValueHtml_Empty_ReturnsEmpty()
+        {
+            var form = new CHtmlFormatting();
+
+            string result = form.RenderMultiValueHtml(string.Empty);
+
+            Assert.Equal(string.Empty, result);
+        }
+    }
+}

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTableTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/Registry/CRegKeysTableTEST.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System.Collections.Generic;
+using VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Registry;
+using VeeamHealthCheck.Shared;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.Registry
+{
+    /// <summary>
+    /// Tests that CRegKeysTable only converts the "|" multi-value delimiter to a line
+    /// break for registry entries that were actually joined from a multi-value
+    /// (string[]) registry key, per PR #203 review finding: a single-value entry may
+    /// legitimately contain a literal "|" character that must not be corrupted.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Collection("GlobalState")]
+    public class CRegKeysTableTEST
+    {
+        [Fact]
+        public void Render_MultiValueRegistryKey_ConvertsDelimiterToLineBreak()
+        {
+            var originalKeys = CGlobals.DEFAULTREGISTRYKEYS;
+            var originalJson = CGlobals.FullReportJson;
+            CGlobals.DEFAULTREGISTRYKEYS = new Dictionary<string, object>
+            {
+                ["VhcTest_MultiValueKey"] = new[] { "austriaeast", "brazilsoutheast" },
+            };
+
+            try
+            {
+                string html = new CRegKeysTable().Render(scrub: false);
+
+                Assert.Contains("austriaeast<br>brazilsoutheast", html);
+                Assert.DoesNotContain("austriaeast|brazilsoutheast", html);
+            }
+            finally
+            {
+                CGlobals.DEFAULTREGISTRYKEYS = originalKeys;
+                CGlobals.FullReportJson = originalJson;
+            }
+        }
+
+        [Fact]
+        public void Render_SingleValueRegistryKeyContainingLiteralPipe_LeavesPipeUnchanged()
+        {
+            var originalKeys = CGlobals.DEFAULTREGISTRYKEYS;
+            var originalJson = CGlobals.FullReportJson;
+            CGlobals.DEFAULTREGISTRYKEYS = new Dictionary<string, object>
+            {
+                ["VhcTest_SingleValueKeyWithPipe"] = "C:\\Path|WithLiteralPipe",
+            };
+
+            try
+            {
+                string html = new CRegKeysTable().Render(scrub: false);
+
+                Assert.Contains("C:\\Path|WithLiteralPipe", html);
+                Assert.DoesNotContain("C:\\Path<br>WithLiteralPipe", html);
+            }
+            finally
+            {
+                CGlobals.DEFAULTREGISTRYKEYS = originalKeys;
+                CGlobals.FullReportJson = originalJson;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **#171** — `RegOptions()`, `SummarizeRoleTypes()`, and `SetGateHosts()` (a third, previously-unreported instance of the same bug) now join multi-value fields with `|` instead of `<br>`. HTML rendering call sites convert `|` back to `<br>` for display; the JSON export path keeps the plain `|`-delimited value. See [ADR 0029](docs/adr/0029-html-free-values-in-json-export-producers.md).
- **#172** — Removed the always-null `cProtectedWorkloads` and `LicenseSummary` top-level fields from `CFullReportJson`. Equivalent live data already exists under `Sections["protectedWorkloads"]` and `Licenses[]`. [ADR 0028](docs/adr/0028-nested-json-via-dedicated-property.md) gets a short addendum since it cited `cProtectedWorkloads` as precedent.
- Added `CFullReportJson.VhcVersion`, stamped from `CGlobals.VHCVERSION` in `CHtmlExporter.ExportJsonReport()` — every JSON report now records the vHC version that produced it.
- Filed #202 as a separate follow-up for an unrelated dead-code finding from triage (`CHtmlTables.ExportJson(string,bool)` has no callers) — intentionally not touched in this PR.

Fixes #171, fixes #172

## Test Plan

- [x] `HC_Reporting` (production project) builds cross-platform with 0 errors, confirmed locally — covers all 7 production-code edits.
- [ ] New xUnit facts added (`CDataFormerJsonDelimiterTEST`, `CFullReportJsonTEST`, and an addition to `CHtmlExporterTEST`) — `VhcXTests` disables compilation on non-Windows (`EnableDefaultCompileItems=false`), so these need CI (`windows-latest`) to actually run.