### PR TITLE
fix(gui): surface report-phase exceptions instead of exiting 0 silently

### DIFF
--- a/vHC/HC_Reporting/VhcGui.xaml.cs
+++ b/vHC/HC_Reporting/VhcGui.xaml.cs
@@ -249,15 +249,53 @@ namespace VeeamHealthCheck
         {
             System.Threading.Tasks.Task.Factory.StartNew(() =>
             {
-                this.functions.StartPrimaryFunctions();
-                this.UpdateCollectionStatusText();
-                this.OfferMonitorSetupIfNeeded();
-                this.ShowCollectionWarningsIfAny();
-                Environment.Exit(0);
+                // The whole run happens on a background task. Historically the body
+                // had no try/catch, so any exception in analysis/report generation was
+                // stored on the faulted task and never observed: no report was written,
+                // no error surfaced, Environment.Exit(0) was skipped, and the user was
+                // left staring at a hung-looking GUI. Catch here so failures are logged,
+                // surfaced, and the GUI returns to a usable state. Only exit(0) on success.
+                try
+                {
+                    this.functions.StartPrimaryFunctions();
+                    this.UpdateCollectionStatusText();
+                    this.OfferMonitorSetupIfNeeded();
+                    this.ShowCollectionWarningsIfAny();
+                    Environment.Exit(0);
+                }
+                catch (Exception ex)
+                {
+                    this.ReportRunFailure(ex);
+                }
             }).ContinueWith(t =>
             {
                 this.hideProgressBar();
             });
+        }
+
+        private void ReportRunFailure(Exception ex)
+        {
+            CGlobals.Logger.Error("Run failed: " + ex.Message, true);
+            CGlobals.Logger.Error("Stack trace: " + ex.StackTrace, false);
+            if (ex.InnerException != null)
+            {
+                CGlobals.Logger.Error("Inner exception: " + ex.InnerException.Message, false);
+                CGlobals.Logger.Error("Inner stack trace: " + ex.InnerException.StackTrace, false);
+            }
+
+            this.Dispatcher.Invoke((Action)(() =>
+            {
+                MessageBox.Show(
+                    "The health check failed before a report was generated:\n\n" +
+                    ex.Message +
+                    "\n\nNo report was produced. See the log for the full stack trace.",
+                    "Health Check Failed",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+
+                // Re-enable the run button so the user can retry without restarting.
+                run.IsEnabled = true;
+            }));
         }
 
         private void UpdateCollectionStatusText()


### PR DESCRIPTION
## Problem

When run via the **GUI**, `VhcGui.Run()` executed the entire collection + analysis + report pipeline inside a fire-and-forget `Task.Factory.StartNew` with **no try/catch**. Any exception in `StartAnalysis()` / report generation was stored on the faulted task and never observed:

- no report was written,
- no error surfaced to the user,
- the success-path `Environment.Exit(0)` was skipped, and
- the process exited 0 when the user eventually closed the hung-looking GUI.

**Field symptom:** the output folder contains only the collected CSVs, the log ends with a long silent gap then `The result is: 0`, and the user sees no report and no error. Diagnosed from a customer log on v3.0.1.193 (collection completed at the log-parser tail; the analysis phase logged nothing before exit).

The **CLI** path is unaffected — it runs synchronously under `EntryPoint.Main`'s try/catch, which already logs the exception and returns exit 1.

## Fix

Wrap the run body in try/catch. On failure: log the full exception (message, stack, inner), show an error `MessageBox` pointing at the log, and re-enable the run button so the user can retry. `Environment.Exit(0)` now runs only on the success path.

## Testing

- Not built/tested on this machine (WPF / `net8.0-windows7.0` is Windows-only). Relying on CI runners to validate compile.
- Behavioral repro pending on a Windows box via CLI `/import` against the customer's collected CSVs, to also confirm whether the underlying throw is already addressed by #192 / #194.

## Notes

No matching open issue for this silent-failure class (closest #160, #178 are different), so no `Fixes #N`. Happy to file a tracking issue if wanted.