### PR TITLE
chore(jobs): log NeedsSweep natural-gate vs override and sweep duration

### DIFF
--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcJob.Tests.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcJob.Tests.ps1
@@ -590,6 +590,38 @@ Describe 'Performance gate: sweep triggers on unrecognized job types' {
         $script:UnscopedCalls | Should -Be 1
     }
 
+    It 'logs the natural gate value separately from the overridden effective gate' {
+        $script:LogMessages = [System.Collections.Generic.List[string]]::new()
+        Mock Write-LogFile -MockWith { $script:LogMessages.Add($Message) }
+        Mock Get-VBRJob -MockWith {
+            @(
+                (script:New-FakeJob -Name 'VMwareJob' -TypeToString 'VMware Backup' -LastBackup ([PSCustomObject]@{ Id = [guid]::NewGuid() })),
+                (script:New-FakeJob -Name 'HyperVJob' -TypeToString 'Hyper-V Backup' -LastBackup ([PSCustomObject]@{ Id = [guid]::NewGuid() }))
+            )
+        }
+        Get-VhcJob
+        $SweepLine = $script:LogMessages | Where-Object { $_ -match '^Restore point sweep:' } | Select-Object -Last 1
+        $SweepLine | Should -Match 'natural-gate=False'
+        $SweepLine | Should -Match 'effective-gate=True'
+    }
+
+    It 'logs the sweep duration alongside restore point and job counts' {
+        $script:LogMessages = [System.Collections.Generic.List[string]]::new()
+        Mock Write-LogFile -MockWith { $script:LogMessages.Add($Message) }
+        $MorpheusJob = script:New-FakeJob -Name 'MorpheusJob' -TypeToString 'HPE Morpheus VME Backup'
+        Mock Get-VBRJob -MockWith { @($MorpheusJob) }
+        Mock Get-VBRRestorePoint -MockWith {
+            if ($null -eq $Backup) {
+                @( (script:New-FakeRestorePoint -ObjectId ([guid]'21212121-2121-2121-2121-212121212121') -ApproxSize 4GB -BackupSize 1GB -SourceJob $MorpheusJob) )
+            } else { @() }
+        }
+        Get-VhcJob
+        $SweepLine = $script:LogMessages | Where-Object { $_ -match '^Restore point sweep:' } | Select-Object -Last 1
+        $SweepLine | Should -Match '\d+ms elapsed'
+        $SweepLine | Should -Match '\b1 restore points\b'
+        $SweepLine | Should -Match '\b1 jobs\b'
+    }
+
     # SKIPPED (2026-08-26): Get-VhcJob.ps1 currently forces $NeedsSweep =
     # $true unconditionally (temporary override, see that file's comment
     # near $KnownSafeJobTypes) to close a data-completeness gap for the

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcJob.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcJob.ps1
@@ -96,6 +96,7 @@ function Get-VhcJob {
     )
 
     $NeedsSweep = [bool]($Jobs | Where-Object { $null -ne $_ -and $_.TypeToString -notin $KnownSafeJobTypes } | Select-Object -First 1)
+    $NeedsSweepNatural = $NeedsSweep
 
     # TEMPORARY OVERRIDE (2026-08-26, Ben Thomas) - DO NOT LEAVE IN PLACE:
     # forces every collection run through the global sweep, bypassing the
@@ -136,6 +137,7 @@ function Get-VhcJob {
         CandidateGroups = [System.Collections.Generic.List[object]]::new()
     }
     if ($NeedsSweep) {
+        $SweepStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         try {
             $AllRestorePoints = @(Get-VBRRestorePoint -WarningAction SilentlyContinue | Where-Object { $null -ne $_ })
 
@@ -289,6 +291,15 @@ function Get-VhcJob {
             } catch {}
             try {
                 Write-LogFile "BackupId grouping: $($AllRestorePoints.Count) restore points reduced to $($Groups.Count) groups ($($Groups.Count) tier-1 lookups + $($UnresolvedGroups.Count) tier-2 lookups attempted, vs. $($AllRestorePoints.Count) lookups pre-grouping)"
+            } catch {}
+            # Perf diagnostics for the temporary NeedsSweep override above: natural-gate
+            # is what ADR 0022's allowlist would have decided on its own, so a future
+            # perf complaint can be checked against whether the override actually
+            # changed the outcome for that run (natural-gate=False) or the sweep would
+            # have run anyway (natural-gate=True, reverting the override wouldn't help).
+            try {
+                $SweepStopwatch.Stop()
+                Write-LogFile "Restore point sweep: $($SweepStopwatch.ElapsedMilliseconds)ms elapsed, $($AllRestorePoints.Count) restore points, $(@($Jobs).Count) jobs, natural-gate=$NeedsSweepNatural, effective-gate=$NeedsSweep"
             } catch {}
         } catch {
             # This is the sweep's outermost catch - unlike the Write-LogFile


### PR DESCRIPTION
## Summary

`Get-VhcJob.ps1` forces `$NeedsSweep = $true` unconditionally (temporary override added in PR #198) to close a data-completeness gap for Orphaned/Superseded reporting, at an unmeasured performance cost. That override is shipping in the next dev→master release as-is.

This adds the diagnostics needed to evaluate it later: `$NeedsSweepNatural` (what ADR 0022's allowlist gate would have decided on its own, before the override) and a `Stopwatch` around the sweep, logged together with restore-point/job counts. When a customer reports a performance issue going forward, this lets us check against real data instead of guessing:

- `natural-gate=True` → the sweep would have run for that environment anyway; reverting the override wouldn't change anything for them.
- `natural-gate=False` → the sweep is only running because of the override; reverting would skip it for them.
- `ElapsedMilliseconds` + restore-point/job counts → how expensive the sweep actually was for that run's environment size.

No behavior change — diagnostics only.

Fixes # (none — no tracking issue, ride-along on the temporary-override follow-up work)

---

## Changelog

### 🧪 Tests & CI
- Add Pester coverage for the new sweep-diagnostics log line (natural vs. effective gate, duration/counts)

---

## Review Details

### Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

- Added 2 new Pester tests to `Get-VhcJob.Tests.ps1` (TDD: watched both fail before implementing, then pass after).
- Ran the full `Get-VhcJob.Tests.ps1` suite locally via `pwsh`/Pester 6: 47 passed, 9 skipped (pre-existing, unrelated to this change), 0 failed — no regressions.

### Checklist (check all applicable):

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in _hard to understand_ areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes