### PR TITLE
fix(collection): don't discard a completed VBR collection on non-zero PS exit code

### DIFF
--- a/vHC/HC_Reporting/Functions/Collection/CCollections.cs
+++ b/vHC/HC_Reporting/Functions/Collection/CCollections.cs
@@ -641,8 +641,7 @@ namespace VeeamHealthCheck.Functions.Collection
                 CGlobals.Logger.Info("Entering vb365 ps invoker", false);
 
                 // p.InvokeVb365CollectEmbedded();
-                p.InvokeVb365Collect();
-                this.SCRIPTSUCCESS = true;
+                this.SCRIPTSUCCESS = p.InvokeVb365Collect();
             }
         }
 

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
@@ -874,7 +874,7 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             }
         }
 
-        public void InvokeVb365Collect()
+        public bool InvokeVb365Collect()
         {
             this.log.Info("[PS] Enter VB365 collection invoker...", false);
             var scriptFile = this.vb365Script;
@@ -890,14 +890,46 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
                 FileName = "powershell.exe",
                 Arguments = args,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
             };
             this.log.Info("[PS] Starting VB365 Collection Powershell process", false);
             this.log.Info("[PS] [ARGS]: " + safeArgs, false);
             var result = Process.Start(startInfo);
             this.log.Info("[PS] Process started with ID: " + result.Id.ToString(), false);
+
+            // Capture output for diagnostics: the collector's own INFO/WARNING/ERROR
+            // logging goes to CollectorMain.log on disk, not stdout (Write-LogFile only
+            // echoes to the console-only Information/Warning/Error streams, and only
+            // when the script's own DebugInConsole setting is on) - so unlike the VBR
+            // config collector, there is no in-process "collection complete" marker we
+            // can observe from here. The real process exit code is the only reliable
+            // signal available; capturing stdout/stderr at least surfaces PowerShell-
+            // level failures (e.g. module load errors) that were previously silent.
+            var stdOutTask = System.Threading.Tasks.Task.Run(() => result.StandardOutput.ReadToEnd());
+            var stdErrTask = System.Threading.Tasks.Task.Run(() => result.StandardError.ReadToEnd());
             result.WaitForExit();
+            string stdOut = stdOutTask.GetAwaiter().GetResult();
+            string stdErr = stdErrTask.GetAwaiter().GetResult();
+
+            if (!string.IsNullOrWhiteSpace(stdOut))
+            {
+                this.log.Debug($"[PS][VB365][STDOUT] {stdOut}", false);
+            }
+            if (!string.IsNullOrWhiteSpace(stdErr))
+            {
+                this.log.Error($"[PS][VB365][STDERR] {stdErr}", false);
+            }
+
+            if (result.ExitCode != 0)
+            {
+                this.log.Error($"[PS] VB365 script failed with exit code: {result.ExitCode}", false);
+                return false;
+            }
+
             this.log.Info("[PS] VB365 collection complete!", false);
+            return true;
         }
 
         /// <summary>

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
@@ -382,9 +382,9 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
         public bool RunVbrConfigCollect()
         {
             bool success = true;
-            success = this.ExecutePsScript(this.VbrConfigStartInfo());
+            success = this.ExecutePsScript(this.VbrConfigStartInfo(), tolerateExitCodeIfComplete: true);
 
-            
+
             // Skip NAS script during remote execution as it reads from local log files
             // that don't exist on the management machine
             if (success && !CGlobals.REMOTEEXEC)
@@ -399,7 +399,23 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             return success;
         }
 
-        public bool ExecutePsScript(ProcessStartInfo startInfo)
+        // Collection is "complete" if the manifest file (written as the final collection
+        // step, immediately before "Collection complete" is logged) exists on disk; the
+        // stdout marker is a fallback for callers that don't have a manifest path yet.
+        // A real on-disk artifact is the signal here, not a fragile exit-code assumption -
+        // this is what lets us tell "collection finished, teardown hiccuped" apart from
+        // "collection actually failed".
+        internal static bool VbrCollectionCompleted(string stdOut, string manifestPath)
+        {
+            if (!string.IsNullOrEmpty(manifestPath) && File.Exists(manifestPath))
+            {
+                return true;
+            }
+
+            return !string.IsNullOrEmpty(stdOut) && stdOut.Contains("[Get-VBRConfig] Collection complete");
+        }
+
+        public bool ExecutePsScript(ProcessStartInfo startInfo, bool tolerateExitCodeIfComplete = false)
         {
             var res1 = new Process();
             res1.StartInfo = startInfo;
@@ -458,8 +474,17 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             // Check exit code
             if (res1.ExitCode != 0)
             {
-                this.log.Error($"[PS] Script failed with exit code: {res1.ExitCode}", false);
-                failed = true;
+                string manifestPath = Path.Combine(CVariables.vbrDir, $"{CGlobals.REMOTEHOST}_CollectionManifest.csv");
+                if (tolerateExitCodeIfComplete && VbrCollectionCompleted(stdOut, manifestPath))
+                {
+                    this.log.Info($"[PS] Script exited with code {res1.ExitCode} but collection completed " +
+                        "(manifest present / 'Collection complete' logged). Proceeding to report generation.", false);
+                }
+                else
+                {
+                    this.log.Error($"[PS] Script failed with exit code: {res1.ExitCode}", false);
+                    failed = true;
+                }
             }
 
             this.log.Info(CMessages.PsVbrConfigProcIdDone, false);

--- a/vHC/VhcXTests/PSInvokerCompletionTests.cs
+++ b/vHC/VhcXTests/PSInvokerCompletionTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using System.IO;
+using VeeamHealthCheck.Functions.Collection.PSCollections;
+using Xunit;
+
+namespace VhcXTests
+{
+    /// <summary>
+    /// Regression tests for the "collection completed but the PowerShell process still
+    /// exited non-zero" tolerance (customer scenario: an orphaned standalone agent backup
+    /// dirties the VBR session, so the unguarded Disconnect-VBRServer in the script's
+    /// finally block throws and the process returns exit code 2 - even though every
+    /// collector ran and CollectionManifest.csv was written). VbrCollectionCompleted is
+    /// the pure decision helper PSInvoker.ExecutePsScript consults before treating a
+    /// non-zero exit code as fatal.
+    /// </summary>
+    public class PSInvokerCompletionTests
+    {
+        [Fact]
+        public void VbrCollectionCompleted_ManifestPresent_ReturnsTrue()
+        {
+            string manifestPath = Path.Combine(Path.GetTempPath(), $"vhc-test-manifest-{Guid.NewGuid()}.csv");
+            File.WriteAllText(manifestPath, "\"Name\",\"Success\"\r\n");
+            try
+            {
+                Assert.True(PSInvoker.VbrCollectionCompleted(stdOut: null, manifestPath));
+            }
+            finally
+            {
+                File.Delete(manifestPath);
+            }
+        }
+
+        [Fact]
+        public void VbrCollectionCompleted_MarkerInStdoutNoManifest_ReturnsTrue()
+        {
+            string manifestPath = Path.Combine(Path.GetTempPath(), $"vhc-test-manifest-{Guid.NewGuid()}.csv");
+            string stdOut = "[Get-VBRConfig] Collection complete. Output: C:\\temp\\vHC\\Original\\VBR\\localhost\\20260609_150942";
+
+            Assert.False(File.Exists(manifestPath));
+            Assert.True(PSInvoker.VbrCollectionCompleted(stdOut, manifestPath));
+        }
+
+        [Fact]
+        public void VbrCollectionCompleted_NoManifestNoMarker_ReturnsFalse()
+        {
+            string manifestPath = Path.Combine(Path.GetTempPath(), $"vhc-test-manifest-{Guid.NewGuid()}.csv");
+            string stdOut = "[Get-VBRConfig] Get-VhcServer returned null - aborting. Check VBR connectivity and logs.";
+
+            Assert.False(File.Exists(manifestPath));
+            Assert.False(PSInvoker.VbrCollectionCompleted(stdOut, manifestPath));
+        }
+
+        [Fact]
+        public void VbrCollectionCompleted_EmptyInputs_ReturnsFalse()
+        {
+            Assert.False(PSInvoker.VbrCollectionCompleted(stdOut: null, manifestPath: null));
+            Assert.False(PSInvoker.VbrCollectionCompleted(stdOut: string.Empty, manifestPath: string.Empty));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #178. `PSInvoker.ExecutePsScript` treated any non-zero PowerShell exit code as fatal, so `CCollections.WeighSuccessContinuation` called `Environment.Exit(1)` before report generation was ever reached — discarding a fully-collected dataset. Field case: an orphaned standalone agent backup (parent job deleted) dirties the VBR PowerShell session when `GetJob()` throws; the (separately, already-fixed) unguarded `Disconnect-VBRServer` in `Get-VBRConfig.ps1`'s `finally` block then throws on the dirty session, returning exit code 2 — even though `CollectionManifest.csv` was written with all 21 collectors marked `True` and every CSV was present. VHC aborted with no report on 4 of 5 runs against the same environment.

## Changes

- Add `PSInvoker.VbrCollectionCompleted(stdOut, manifestPath)`: a pure check for whether collection actually finished (`CollectionManifest.csv` exists on disk, or the `"[Get-VBRConfig] Collection complete"` stdout marker as fallback).
- `ExecutePsScript` gains an opt-in `tolerateExitCodeIfComplete` flag, set `true` only for the VBR config collect (`RunVbrConfigCollect`) — NAS/VB365 collection behavior is unchanged. When collection completed, a non-zero exit is now logged as informational and the run proceeds to report generation instead of aborting. A genuine failure (no manifest, no completion marker) still aborts exactly as before.
- Related hardening: `InvokeVb365Collect()` previously hardcoded `SCRIPTSUCCESS = true` after VB365 collection regardless of outcome, making VB365 failures invisible. It now captures stdout/stderr and returns success based on the real process exit code.

This is a **standard merge, not a squash** — please merge as-is to keep both commits (VBR-side + VB365-side) distinct in `dev`'s history.

Fixes #178

---

## Changelog

### 🐛 Bug Fixes
- Don't discard a completed VBR collection on a non-zero PowerShell exit code (#178)
- Report the real VB365 collection outcome instead of a hardcoded success

---

## Review Details

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

Authored by Adam Congdon on 2026-07-15, the same day #178 was filed. Verified locally: merges cleanly into current `dev` with no conflicts (`CCollections.cs`, `PSInvoker.cs`, plus new `PSInvokerCompletionTests.cs`).

### Checklist (check all applicable):

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes