### PR TITLE
fix(jobs): isolate per-restore-point GetStorage() failures from job totals

### DIFF
--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcJob.Tests.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcJob.Tests.ps1
@@ -288,6 +288,7 @@ BeforeAll {
             [datetime]$CreationTimeUtc = (Get-Date),
             [double]$ApproxSize = 1GB,
             [double]$BackupSize = 1GB,
+            [switch]$ThrowOnGetStorage,
             $SourceJob = $null,
             [switch]$ThrowOnGetSourceJob,
             [switch]$ThrowOnGetBackup,
@@ -314,13 +315,14 @@ BeforeAll {
         $CallCounts = if ($script:CallCounts) { $script:CallCounts } else { @{ GetSourceJob = 0; GetBackup = 0 } }
 
         $RestorePoint = [PSCustomObject]@{
-            Name            = $Name
-            Type            = $Type
-            ObjectId        = $ObjectId
-            BackupId        = $BackupId
-            CreationTimeUtc = $CreationTimeUtc
-            ApproxSize      = $ApproxSize
-            BackupSizeValue = $BackupSize
+            Name              = $Name
+            Type              = $Type
+            ObjectId          = $ObjectId
+            BackupId          = $BackupId
+            CreationTimeUtc   = $CreationTimeUtc
+            ApproxSize        = $ApproxSize
+            BackupSizeValue   = $BackupSize
+            ThrowOnGetStorage = [bool]$ThrowOnGetStorage
         }
         $RestorePoint | Add-Member -MemberType ScriptMethod -Name GetSourceJob -Value {
             $CallCounts.GetSourceJob = $CallCounts.GetSourceJob + 1
@@ -333,6 +335,7 @@ BeforeAll {
             return $FakeBackup
         }.GetNewClosure()
         $RestorePoint | Add-Member -MemberType ScriptMethod -Name GetStorage -Value {
+            if ($this.ThrowOnGetStorage) { throw 'GetStorage failed' }
             [PSCustomObject]@{ Stats = [PSCustomObject]@{ BackupSize = $this.BackupSizeValue } }
         }
         return $RestorePoint
@@ -1309,6 +1312,83 @@ Describe 'Multi-chain summing for a single tier-1-matched job' {
         $Row = $script:CapturedJobRows | Where-Object { $_.Name -eq 'RetargetedJob' }
         $Row.OnDiskGB     | Should -Be 7      # 3 + 4, both chains summed
         $Row.OriginalSize | Should -Be 15GB   # only the newer chain's ApproxSize
+    }
+}
+
+# ---------------------------------------------------------------------------
+# #199: a per-restore-point GetStorage() failure must not zero the whole job
+# ---------------------------------------------------------------------------
+Describe 'Per-restore-point GetStorage() failure is isolated from job totals (#199)' {
+
+    BeforeEach {
+        $script:CapturedJobRows = @()
+        $script:LogMessages     = [System.Collections.Generic.List[string]]::new()
+        Mock Write-LogFile                 -MockWith { $script:LogMessages.Add($Message) }
+        Mock Get-VBRConfigurationBackupJob -MockWith { $null }
+        Mock Invoke-VhciJobSubCollectors   -MockWith { }
+        Mock Add-VhciModuleError           -MockWith { }
+        Mock Get-VBRBackup                 -MockWith { @() }
+        Mock Export-VhciCsv -MockWith {
+            if ($FileName -eq '_Jobs.csv' -and $InputObject) {
+                $script:CapturedJobRows += @($InputObject)
+            }
+        }
+    }
+
+    It 'sums the surviving restore points and logs a WARNING, instead of zeroing the whole job' {
+        $Job = script:New-FakeJob -Name 'Entra ID Tenant Backup' -TypeToString 'Entra ID Tenant Backup'
+        Mock Get-VBRJob -MockWith { @($Job) }
+
+        # Throwing point deliberately listed FIRST, with TWO healthy
+        # siblings: a fix that still aborts on the first throw (e.g. an
+        # unconverted .ForEach{}, or a stray `break`) would otherwise pass
+        # a throw-last/single-sibling fixture, since the outer per-job
+        # catch zeroes the total either way once nothing downstream runs.
+        Mock Get-VBRRestorePoint -MockWith {
+            if ($null -eq $Backup) {
+                @(
+                    (script:New-FakeRestorePoint -Name 'UnresolvableStorage' -ObjectId ([guid]'00000000-0000-0000-0000-000000000001') -BackupSize 3GB -SourceJob $Job -ThrowOnGetStorage),
+                    (script:New-FakeRestorePoint -Name 'GoodPoint1'          -ObjectId ([guid]'00000000-0000-0000-0000-000000000002') -BackupSize 4GB -SourceJob $Job),
+                    (script:New-FakeRestorePoint -Name 'GoodPoint2'          -ObjectId ([guid]'00000000-0000-0000-0000-000000000003') -BackupSize 5GB -SourceJob $Job)
+                )
+            } else { @() }
+        }
+
+        Get-VhcJob
+        $Row = $script:CapturedJobRows | Where-Object { $_.Name -eq 'Entra ID Tenant Backup' }
+
+        $Row.OnDiskGB | Should -Be 9   # 4 + 5; the unresolvable point is excluded, not zeroing the sum
+
+        @($script:LogMessages | Where-Object { $_ -match 'UnresolvableStorage' -and $_ -match 'Entra ID Tenant Backup' }) | Should -HaveCount 1
+
+        # Must not fall through to the outer per-job catch/IncludedSize
+        # fallback - that path logs different wording than the per-point warning above.
+        @($script:LogMessages | Where-Object { $_ -match 'Could not calculate restore point sizes' }) | Should -HaveCount 0
+    }
+
+    It 'still reports OnDiskGB of 0 but logs one WARNING per point when every restore point is unresolvable' {
+        # Live-confirmed shape (Entra ID Tenant Backup, StorageId all zeros):
+        # every point throws, so the sum is legitimately 0 - #199 doesn't
+        # make that job report a nonzero size, it makes the 0 traceable to
+        # a resolution failure instead of indistinguishable from "empty".
+        $Job = script:New-FakeJob -Name 'Entra ID Tenant Backup' -TypeToString 'Entra ID Tenant Backup'
+        Mock Get-VBRJob -MockWith { @($Job) }
+        Mock Get-VBRRestorePoint -MockWith {
+            if ($null -eq $Backup) {
+                @(
+                    (script:New-FakeRestorePoint -Name 'Unresolvable1' -ObjectId ([guid]'00000000-0000-0000-0000-000000000001') -BackupSize 3GB -SourceJob $Job -ThrowOnGetStorage),
+                    (script:New-FakeRestorePoint -Name 'Unresolvable2' -ObjectId ([guid]'00000000-0000-0000-0000-000000000002') -BackupSize 4GB -SourceJob $Job -ThrowOnGetStorage)
+                )
+            } else { @() }
+        }
+
+        Get-VhcJob
+        $Row = $script:CapturedJobRows | Where-Object { $_.Name -eq 'Entra ID Tenant Backup' }
+
+        $Row.OnDiskGB | Should -Be 0
+        @($script:LogMessages | Where-Object { $_ -match 'Unresolvable1' }) | Should -HaveCount 1
+        @($script:LogMessages | Where-Object { $_ -match 'Unresolvable2' }) | Should -HaveCount 1
+        @($script:LogMessages | Where-Object { $_ -match 'Could not calculate restore point sizes' }) | Should -HaveCount 0
     }
 }
 

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcJob.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/vHC-VbrConfig/Public/Get-VhcJob.ps1
@@ -497,10 +497,13 @@ function Get-VhcJob {
 
             $TotalOnDiskGB = 0
 
-            $RestorePoints.ForEach{
-                $RestorePoint  = $PSItem
-                $OnDiskGB      = $RestorePoint.GetStorage().Stats.BackupSize / 1GB
-                $TotalOnDiskGB += $OnDiskGB
+            foreach ($RestorePoint in $RestorePoints) {
+                try {
+                    $OnDiskGB       = $RestorePoint.GetStorage().Stats.BackupSize / 1GB
+                    $TotalOnDiskGB += $OnDiskGB
+                } catch {
+                    try { Write-LogFile "Could not read on-disk size for restore point '$($RestorePoint.Name)' (ObjectId $($RestorePoint.ObjectId)) in job '$($Job.Name)': $($_.Exception.Message)" -LogLevel "WARNING" } catch {}
+                }
             }
 
             # CalculatedOriginalSize: prefer ApproxSize from latest restore point per object;


### PR DESCRIPTION
## Summary

- `Get-VhcJob.ps1`'s `TotalOnDiskGB` sum used a bare `.ForEach{}` calling `.GetStorage()` per restore point with no per-point error handling. One unresolvable point (confirmed live: a plugin-backed "Entra ID Tenant Backup" job where every `Full` restore point has `StorageId = 00000000-0000-0000-0000-000000000000`) threw on the *first* point, aborting the whole `.ForEach{}` and propagating to the job's outer `catch`, which zeroed `TotalOnDiskGB` for the **entire job** — a silent 0/0 report indistinguishable from a genuinely empty job.
- Replaced the `.ForEach{}` with a plain `foreach` loop (this file already documents, a few lines above, that `.ForEach{}` is silently shadowed/no-ops if the collection is ever a `List[T]` rather than a plain array — a plain `foreach` is safe regardless of collection type) wrapping a per-point `try`/`catch`: a bad point logs a WARNING (naming the job and restore point) and is skipped from the sum; healthy siblings still get summed. The warning log call is itself wrapped in a try/catch (matching this file's own line-537 precedent) so a logging failure can't re-trigger the same zero-the-whole-job failure mode.
- Mirrors the precedent already shipped for the sibling Orphaned/Superseded collector (`Get-VhciBackupSizeOrNull`, #192/#197), adapted for a running **sum** rather than an average (skip-and-continue, not null-filter downstream).

**Known residual gap, out of scope for this fix:** for a job where *every* restore point is unresolvable (the live Entra ID Tenant Backup case), `OnDiskGB` will still report `0` after this fix — that sum is legitimately zero once every contributing point is excluded. What changes is that the logs now name each failing restore point instead of one generic outer-catch line, so the 0 is traceable to a resolution failure rather than silently indistinguishable from an empty job. `CalculatedOriginalSize`/"Original Size" has the same residual-zero behavior for the same job, since it separately falls back to `Job.Info.IncludedSize` (also 0 here) — untouched by and out of scope for this fix.

Fixes #199

## Test plan

- [x] Added a Pester test reproducing the bug (one throwing point + two healthy siblings) — confirmed RED against pre-fix code (`OnDiskGB` was 0), confirmed GREEN after the fix (`OnDiskGB` = 9, sum of the two survivors).
- [x] Added a second test for the all-points-throw case, asserting `OnDiskGB` is legitimately `0` but each failure is logged individually (no outer per-job catch fallback).
- [x] Full `Get-VhcJob.Tests.ps1` suite: 49 passed, 0 failed, 9 skipped (skips are pre-existing/unrelated — documented `$NeedsSweep` override gap, not touched by this fix).
- [x] Sibling `Get-VhcOrphanedSupersededBackups.Tests.ps1` suite: 16 passed, 0 failed (no regression to the precedent this fix mirrors).
- Note: `Get-VhcJob.Tests.ps1` is not wired into any GitHub Actions workflow (`.github/workflows/pester-tests.yml` is path-filtered to `TestMfa.Tests.ps1` only) — the local Pester run above is the only gate for this change.