### PR TITLE
fix(nas): instrument Get-NasInfo.ps1 so the NAS phase is never silent

### DIFF
--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
@@ -814,6 +814,14 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
                     argString += $"-ReportPath \"{path}\" ";
                     safeArgString += $"-ReportPath \"{path}\" ";
                 }
+                // Add LogPath so this phase (e.g. Get-NasInfo) writes its own log next to the
+                // configured output root instead of running silently. Mirrors VbrConfigStartInfo.
+                if (!string.IsNullOrEmpty(CVariables.unsafeDir))
+                {
+                    string nasLogPath = Path.Combine(CVariables.unsafeDir, "Log");
+                    argString += $"-LogPath \"{nasLogPath}\" ";
+                    safeArgString += $"-LogPath \"{nasLogPath}\" ";
+                }
                 if (needsCredentials)
                 {
                     CredsHandler ch = new();

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
@@ -4,7 +4,9 @@ param(
     [Parameter(Mandatory)]
     [int]$VBRVersion,
     [Parameter(Mandatory = $false)]
-    [string]$ReportPath = ""
+    [string]$ReportPath = "",
+    [Parameter(Mandatory = $false)]
+    [string]$LogPath = ""
 )
 
 # Self-contained CSV formula-injection neutralizer (this script runs standalone,
@@ -35,59 +37,107 @@ function Protect-VhciCsvInjection {
     }
 }
 
+# Self-contained logger. This script runs as its own PowerShell process (launched by
+# PSInvoker), so it cannot use the vHC-VbrConfig module's Write-LogFile. Every line is
+# written to STDOUT (captured by the GUI as [PS][STDOUT]) and appended to its own log
+# file when a log directory is resolvable. This phase used to run completely silently,
+# which is why a slow or stuck VMC.log parse looked like the whole tool hanging.
+$script:NasLogFile = $null
+function Write-NasLog {
+    param([string]$Message, [string]$Level = 'INFO')
+    $line = "{0} [{1}] [Get-NasInfo] {2}" -f (Get-Date).ToString('yyyy-MM-dd HH:mm:ss'), $Level, $Message
+    try { [Console]::Out.WriteLine($line) } catch { }
+    if ($script:NasLogFile) {
+        try { [System.IO.File]::AppendAllText($script:NasLogFile, $line + [Environment]::NewLine) } catch { }
+    }
+}
+
 # If ReportPath not provided, use default with server name and timestamp structure
 if ([string]::IsNullOrEmpty($ReportPath)) {
     $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
     $ReportPath = "C:\temp\vHC\Original\VBR\$VBRServer\$timestamp"
 }
 
-# VMC log path is hardcoded for now. If logs are sent elsewhere, please adjust accordingly.
- $logsPath = "C:\ProgramData\Veeam\Backup\Utils\VMC.log"
+# Resolve the log file. Fall back to ReportPath when no LogPath was passed so the phase
+# is never silent, even when invoked standalone.
+if ([string]::IsNullOrEmpty($LogPath)) { $LogPath = $ReportPath }
+try {
+    if (-not (Test-Path -LiteralPath $LogPath)) { New-Item -Path $LogPath -ItemType Directory -Force | Out-Null }
+    $script:NasLogFile = Join-Path $LogPath "Get-NasInfo.log"
+} catch {
+    $script:NasLogFile = $null
+}
 
- # section identifiers
- $unstrucStart = "=====UNSTRUCTURED DATA===="
-  $nasStart = "=====NAS INFRASTRUCTURE===="
- $sectionEnd = "========"
- 
- #get file info and set empty containers.
- if (Test-Path -LiteralPath $logsPath) {
-     $content = Get-Content -LiteralPath $logsPath
- } else {
-     Write-Verbose "VMC.log not found at $logsPath - skipping unstructured/NAS section parsing"
-     $content = @()
- }
- $sections = @()
- $currentSection = @()
- $capturing = $false
- 
- foreach($line in $content){
-     if(-not $capturing -and $line -match $unstrucStart){
-         $capturing = $true
-         $currentSection = @()
-     }
-     elseif(-not $capturing -and $line -match $nasStart){
-        $capturing = $true
-        $currentSection = @()
+$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+Write-NasLog "Starting. VBRServer=$VBRServer VBRVersion=$VBRVersion ReportPath=$ReportPath PS=$($PSVersionTable.PSVersion)"
+
+try {
+    # VMC log path is hardcoded for now. If logs are sent elsewhere, please adjust accordingly.
+    $logsPath = "C:\ProgramData\Veeam\Backup\Utils\VMC.log"
+
+    # section identifiers
+    $unstrucStart = "=====UNSTRUCTURED DATA===="
+    $nasStart = "=====NAS INFRASTRUCTURE===="
+    $sectionEnd = "========"
+
+    # Report VMC.log presence and size up front -- this is the single most useful signal
+    # for diagnosing a "hang": a missing file finishes instantly, a multi-GB file is the
+    # slow read. Get-Item is guarded so a mocked/absent path never throws.
+    if (Test-Path -LiteralPath $logsPath) {
+        $vmcSizeInfo = "size unavailable"
+        try {
+            $fi = Get-Item -LiteralPath $logsPath -ErrorAction Stop
+            $vmcSizeInfo = "{0:N1} MB, last written {1}" -f (($fi.Length) / 1MB), $fi.LastWriteTime
+        } catch { }
+        Write-NasLog "VMC.log found at $logsPath ($vmcSizeInfo). Reading..."
+        $readSw = [System.Diagnostics.Stopwatch]::StartNew()
+        $content = Get-Content -LiteralPath $logsPath
+        $readSw.Stop()
+        Write-NasLog ("Read {0} line(s) in {1:N1}s" -f @($content).Count, ($readSw.Elapsed.TotalSeconds))
+    } else {
+        Write-NasLog "VMC.log not found at $logsPath - skipping unstructured/NAS section parsing" 'WARNING'
+        Write-Verbose "VMC.log not found at $logsPath - skipping unstructured/NAS section parsing"
+        $content = @()
     }
-     elseif($capturing){
-         if($line -match $sectionEnd){
-             $capturing = $false
-             $sections += ,($currentSection)
-             $currentSection = @()
-         }
-         else{
-             if (-not ($line -match '\[VmcStats\]')) {
-                 $stripped = $line -replace '^\[[\d.:\s]+\]\s+\d+(?:\s+\[\w+\])?\s+\w+\s+\(\d+\)\s+', ''
-                 $currentSection += $stripped
-             }
-         }
-     }
- }
- 
- # Here we set a new list to only contain the final data section from the log:
- $dataLines = $sections[$sections.Count-1]
 
- # search each line, looking for these strings: TotalObjectStorageSize, NasBackupSourceShareStats, TotalShareSize. Group each into their own list
+    $sections = @()
+    $currentSection = @()
+    $capturing = $false
+
+    $lineNum = 0
+    foreach($line in $content){
+        $lineNum++
+        if (($lineNum % 200000) -eq 0) {
+            Write-NasLog ("Scanning VMC.log... {0}/{1} lines, {2} section(s) captured" -f $lineNum, @($content).Count, $sections.Count)
+        }
+        if(-not $capturing -and $line -match $unstrucStart){
+            $capturing = $true
+            $currentSection = @()
+        }
+        elseif(-not $capturing -and $line -match $nasStart){
+           $capturing = $true
+           $currentSection = @()
+       }
+        elseif($capturing){
+            if($line -match $sectionEnd){
+                $capturing = $false
+                $sections += ,($currentSection)
+                $currentSection = @()
+            }
+            else{
+                if (-not ($line -match '\[VmcStats\]')) {
+                    $stripped = $line -replace '^\[[\d.:\s]+\]\s+\d+(?:\s+\[\w+\])?\s+\w+\s+\(\d+\)\s+', ''
+                    $currentSection += $stripped
+                }
+            }
+        }
+    }
+    Write-NasLog ("Scan complete: {0} line(s) processed, {1} section(s) found" -f $lineNum, $sections.Count)
+
+    # Here we set a new list to only contain the final data section from the log:
+    $dataLines = $sections[$sections.Count-1]
+
+    # search each line, looking for these strings: TotalObjectStorageSize, NasBackupSourceShareStats, TotalShareSize. Group each into their own list
     $totalObjectStorageSize = @()
     $nasBackupSourceShareStats = @()
     $totalShareSize = @()      # v12: combined single-line records
@@ -112,69 +162,83 @@ if ([string]::IsNullOrEmpty($ReportPath)) {
             $totalShareSize += $_
         }
     }
+    Write-NasLog ("Parsed data section: {0} ObjectStorageSize, {1} SourceShareStats, {2} parent share(s), {3} child share(s), {4} v12 share line(s)" -f `
+        $totalObjectStorageSize.Count, $nasBackupSourceShareStats.Count, $parentShares.Count, $childShares.Count, $totalShareSize.Count)
 
- 
-# Parse a log line into a hashtable of key-value pairs
-function ConvertTo-LogProperties([string]$logLine) {
-    $props = @{}
-    $logLine.Trim() -split ', ' | ForEach-Object {
-        $parts = $_.Split(':', 2)
-        if ($parts.Count -eq 2) {
-            $props[$parts[0].Trim()] = $parts[1].Trim()
+    # Parse a log line into a hashtable of key-value pairs
+    function ConvertTo-LogProperties([string]$logLine) {
+        $props = @{}
+        $logLine.Trim() -split ', ' | ForEach-Object {
+            $parts = $_.Split(':', 2)
+            if ($parts.Count -eq 2) {
+                $props[$parts[0].Trim()] = $parts[1].Trim()
+            }
         }
+        return $props
     }
-    return $props
-}
 
-$csvData = @($totalObjectStorageSize | ForEach-Object { [PSCustomObject](ConvertTo-LogProperties $_) })
-if (!(Test-Path $ReportPath)) { New-Item -Path $ReportPath -ItemType Directory -Force | Out-Null }
-$csvData | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasObjectSourceStorageSize.csv" -NoTypeInformation
+    $csvData = @($totalObjectStorageSize | ForEach-Object { [PSCustomObject](ConvertTo-LogProperties $_) })
+    if (!(Test-Path $ReportPath)) { New-Item -Path $ReportPath -ItemType Directory -Force | Out-Null }
+    $csvData | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasObjectSourceStorageSize.csv" -NoTypeInformation
+    Write-NasLog ("Exported {0} row(s) to {1}_NasObjectSourceStorageSize.csv" -f $csvData.Count, $VBRServer)
 
-$csvData2 = @($nasBackupSourceShareStats | ForEach-Object { [PSCustomObject](ConvertTo-LogProperties $_) })
-$csvData2 | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasFileData.csv" -NoTypeInformation
+    $csvData2 = @($nasBackupSourceShareStats | ForEach-Object { [PSCustomObject](ConvertTo-LogProperties $_) })
+    $csvData2 | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasFileData.csv" -NoTypeInformation
+    Write-NasLog ("Exported {0} row(s) to {1}_NasFileData.csv" -f $csvData2.Count, $VBRServer)
 
-# Parse v12 combined lines
-$v12Rows = @($totalShareSize | ForEach-Object {
-    $props = ConvertTo-LogProperties $_
-    if (-not $props.ContainsKey('ParentServerID')) { $props['ParentServerID'] = $null }
-    [PSCustomObject]$props
-})
+    # Parse v12 combined lines
+    $v12Rows = @($totalShareSize | ForEach-Object {
+        $props = ConvertTo-LogProperties $_
+        if (-not $props.ContainsKey('ParentServerID')) { $props['ParentServerID'] = $null }
+        [PSCustomObject]$props
+    })
 
-# Parse v13 parent lines into a hashtable keyed by FileShareID
-$parentMap = @{}
-$parentShares | ForEach-Object {
-    $props = ConvertTo-LogProperties $_
-    if ($props.ContainsKey('FileShareID')) {
-        $parentMap[$props['FileShareID']] = $props
-    }
-}
-
-# Parse v13 child lines and join with parent
-$v13Rows = @($childShares | ForEach-Object {
-    $childProps = ConvertTo-LogProperties $_
-    $merged = @{}
-
-    # Start with parent properties (if parent found)
-    $parentId = $childProps['ParentServerID']
-    if ($parentId -and $parentMap.ContainsKey($parentId)) {
-        foreach ($key in $parentMap[$parentId].Keys) {
-            $merged[$key] = $parentMap[$parentId][$key]
+    # Parse v13 parent lines into a hashtable keyed by FileShareID
+    $parentMap = @{}
+    $parentShares | ForEach-Object {
+        $props = ConvertTo-LogProperties $_
+        if ($props.ContainsKey('FileShareID')) {
+            $parentMap[$props['FileShareID']] = $props
         }
     }
 
-    # Overlay child properties (child wins on conflict)
-    foreach ($key in $childProps.Keys) {
-        $merged[$key] = $childProps[$key]
-    }
+    # Parse v13 child lines and join with parent
+    $v13Rows = @($childShares | ForEach-Object {
+        $childProps = ConvertTo-LogProperties $_
+        $merged = @{}
 
-    # Ensure ParentServerID always present
-    if (-not $merged.ContainsKey('ParentServerID')) { $merged['ParentServerID'] = $null }
-    [PSCustomObject]$merged
-})
+        # Start with parent properties (if parent found)
+        $parentId = $childProps['ParentServerID']
+        if ($parentId -and $parentMap.ContainsKey($parentId)) {
+            foreach ($key in $parentMap[$parentId].Keys) {
+                $merged[$key] = $parentMap[$parentId][$key]
+            }
+        }
 
-# Union v12 and v13 rows; v13 rows first so the header reflects the full v13 schema
-$allShareRows = @()
-if ($v13Rows.Count -gt 0) { $allShareRows += $v13Rows }
-if ($v12Rows.Count -gt 0) { $allShareRows += $v12Rows }
+        # Overlay child properties (child wins on conflict)
+        foreach ($key in $childProps.Keys) {
+            $merged[$key] = $childProps[$key]
+        }
 
-$allShareRows | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasSharesize.csv" -NoTypeInformation
+        # Ensure ParentServerID always present
+        if (-not $merged.ContainsKey('ParentServerID')) { $merged['ParentServerID'] = $null }
+        [PSCustomObject]$merged
+    })
+
+    # Union v12 and v13 rows; v13 rows first so the header reflects the full v13 schema
+    $allShareRows = @()
+    if ($v13Rows.Count -gt 0) { $allShareRows += $v13Rows }
+    if ($v12Rows.Count -gt 0) { $allShareRows += $v12Rows }
+
+    $allShareRows | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasSharesize.csv" -NoTypeInformation
+    Write-NasLog ("Exported {0} row(s) to {1}_NasSharesize.csv ({2} v13 + {3} v12)" -f $allShareRows.Count, $VBRServer, $v13Rows.Count, $v12Rows.Count)
+}
+catch {
+    Write-NasLog "FAILED: $($_.Exception.Message)" 'ERROR'
+    Write-NasLog "$($_.ScriptStackTrace)" 'ERROR'
+    throw
+}
+finally {
+    $stopwatch.Stop()
+    Write-NasLog ("Completed in {0:N1}s" -f $stopwatch.Elapsed.TotalSeconds)
+}


### PR DESCRIPTION
## Why

Customer report: VHC "runs and never completes / appears to hang." The collector logs show the truth — `Get-VBRConfig.ps1` completed cleanly (all 21 collectors OK, ~8.5 min), then the app launched the **second** script, `Get-NasInfo.ps1` (a parser for `C:\ProgramData\Veeam\Backup\Utils\VMC.log`), and every log dead-ended there.

Root cause of the *black hole*: `Get-NasInfo.ps1` had **zero logging**, received no `-LogPath`, and emitted nothing between launch and its final CSV writes. It slurps the whole VMC.log via one `Get-Content` and parses silently. On a NAS-heavy estate that file is large, so the read/parse runs for minutes and looks like the whole tool is hung — with no way to tell **slow** from **stuck** without going back and forth with the customer.

Note: the rich NAS progress logging that already exists lives in `vHC-VbrConfig/Private/Get-VhciNasJob.ps1` (the *jobs* collector inside Get-VBRConfig). This standalone VMC.log parser never got wired into any of it.

## What (logging only)

`Get-NasInfo.ps1`:
- Self-contained STDOUT + file logger (the module's `Write-LogFile` is unreachable from this standalone process; STDOUT is captured by the GUI as `[PS][STDOUT]`).
- Logs VMC.log **presence, size, last-write time** up front (the key slow-vs-missing-vs-stuck signal), a **timed read**, line count, periodic scan progress (every 200k lines), per-bucket parse counts, and per-CSV row counts.
- `try/catch/finally` — a failure is logged with stack trace and rethrown instead of dying silently; total elapsed always logged.

`PSInvoker.cs`:
- Wire `-LogPath` into the NAS launch so it writes `Get-NasInfo.log` next to the other collector logs (mirrors `VbrConfigStartInfo`).

## Scope / non-goals

Logging only. Parse logic and the VMC.log existence guard are **unchanged**. Deliberately **not** in this PR (tracked separately): a bounded timeout on the NAS launch (currently unbounded `WaitForExit`) and a streamed `-ReadCount` read to fix the underlying slowness. This PR makes the next report self-diagnosing; the perf fix follows.

## Verification

- `Get-NasInfo.Tests.ps1` (Pester 5.7.1): **2/2 pass** — ISC-4 (`Get-Content` 0 calls when VMC.log absent) and ISC-5 (happy-path non-empty CSV). `Get-Item` is guarded so the mocked-present/real-absent case logs `size unavailable` and continues.
- Script parses clean; PS 5.1 compatible (customer runs 5.1).
- ⚠️ `PSInvoker.cs` not compiled here (net8.0-windows target, macOS dev box). Change is a 8-line parity edit of the existing ReportPath pattern using `CVariables.unsafeDir` — needs a Windows build check in CI.