### PR TITLE
fix(cross-platform): make startup, tests, and path building Windows-guard safe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build Commands
 
 ```bash
-# Build the solution (Windows required for full build)
+# Build the solution (plain build works cross-platform; only the
+# self-contained single-file Windows publish requires Windows)
 dotnet build vHC/HC.sln --configuration Debug
 
 # Build release version
@@ -18,7 +19,8 @@ dotnet restore vHC/HC.sln
 ## Test Commands
 
 ```bash
-# Run all tests (Windows only - tests require WPF/.NET Windows)
+# Run all tests (cross-platform; genuinely Windows-only tests are marked
+# [WindowsOnlyFact] and skip automatically off Windows)
 dotnet test vHC/VhcXTests/VhcXTests.csproj
 
 # Run specific test class
@@ -128,7 +130,8 @@ If a PR resolves multiple issues, list them: `Fixes #112, fixes #152, fixes #155
 
 ## Important Notes
 
-- Tests require Windows (WPF dependency) - non-Windows builds skip test compilation
+- Tests build and run on Windows, macOS, and Linux. `EnableWindowsTargeting=true` in `VeeamHealthCheck.csproj` is what lets the `net8.0-windows7.0` TFM build off-Windows at all, combined with the WPF → Avalonia GUI migration (PR #211) replacing the Windows-only UI toolkit. Genuinely Windows-only tests (DPAPI, registry, etc.) are marked `[WindowsOnlyFact]` and skip individually rather than gating the whole suite.
+- A second test project, `VhcXTests.CrossPlatform` (`net10.0`), compiles a hand-picked subset of source files directly rather than referencing `VeeamHealthCheck.csproj`.
 - Internal types exposed to `VhcXTests` via `InternalsVisibleTo` in csproj
 - Version auto-increments on build via `increment_version.ps1`
 - Suppressed code analysis warnings: CA1305, CA1307, CA1820, CA2242, CA1031, CA1806, CA1822

--- a/vHC/HC_Reporting/Functions/Reporting/CsvHandlers/CCsvParser.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/CsvHandlers/CCsvParser.cs
@@ -627,7 +627,16 @@ namespace VeeamHealthCheck.Functions.Reporting.CsvHandlers
             if (string.IsNullOrEmpty(fileName))
                 return null;
 
-            fileName = Path.GetFileName(fileName);
+            // These file names originate from the VBR server's (always-Windows) collection
+            // folder structure, independent of the OS this parser runs on, so the separator
+            // must be treated as literal rather than via Path.GetFileName's host-OS behavior
+            // (which ignores '\' entirely on non-Windows).
+            int lastSeparator = fileName.LastIndexOfAny(new[] { '\\', '/' });
+            if (lastSeparator >= 0)
+            {
+                fileName = fileName[(lastSeparator + 1)..];
+            }
+
             if (!fileName.EndsWith(VbrInfoCsvSuffix, StringComparison.OrdinalIgnoreCase))
                 return null;
 

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CHtmlExporter.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CHtmlExporter.cs
@@ -23,12 +23,9 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
         private readonly CLogger log = CGlobals.Logger;
 
         // path settings
-        // CVariables.safeSuffix/unsafeSuffix are @"\..." literals (other, unfixed
-        // consumers still string-concat them as Windows paths), so TrimStart before
-        // handing them to Path.Combine here to build a genuinely cross-platform path.
         private readonly string basePath = CGlobals.desiredPath;
-        private readonly string anonPath = Path.Combine(CGlobals.desiredPath, CVariables.safeSuffix.TrimStart('\\'));
-        private readonly string origPath = Path.Combine(CGlobals.desiredPath, CVariables.unsafeSuffix.TrimStart('\\'));
+        private readonly string anonPath = CCrossPlatformPath.Combine(CGlobals.desiredPath, CVariables.safeSuffix);
+        private readonly string origPath = CCrossPlatformPath.Combine(CGlobals.desiredPath, CVariables.unsafeSuffix);
 
         private readonly string backupServerName;
         private string latestReport;

--- a/vHC/HC_Reporting/Functions/Reporting/Html/CHtmlExporter.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/CHtmlExporter.cs
@@ -23,9 +23,12 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
         private readonly CLogger log = CGlobals.Logger;
 
         // path settings
+        // CVariables.safeSuffix/unsafeSuffix are @"\..." literals (other, unfixed
+        // consumers still string-concat them as Windows paths), so TrimStart before
+        // handing them to Path.Combine here to build a genuinely cross-platform path.
         private readonly string basePath = CGlobals.desiredPath;
-        private readonly string anonPath = CGlobals.desiredPath + CVariables.safeSuffix;
-        private readonly string origPath = CGlobals.desiredPath + CVariables.unsafeSuffix;
+        private readonly string anonPath = Path.Combine(CGlobals.desiredPath, CVariables.safeSuffix.TrimStart('\\'));
+        private readonly string origPath = Path.Combine(CGlobals.desiredPath, CVariables.unsafeSuffix.TrimStart('\\'));
 
         private readonly string backupServerName;
         private string latestReport;
@@ -264,11 +267,11 @@ namespace VeeamHealthCheck.Functions.Reporting.Html
                 {
                     installID = this.TrySetInstallId(CLogOptions.INSTALLID);
 
-                    htmlCore = this.anonPath + "\\" + this.htmlName + "_" + vbrOrVb365 + "_" + installID + dateTime.ToString("_yyyy.MM.dd.HHmmss") + ".html";
+                    htmlCore = Path.Combine(this.anonPath, this.htmlName + "_" + vbrOrVb365 + "_" + installID + dateTime.ToString("_yyyy.MM.dd.HHmmss") + ".html");
                 }
                 else if (!scrub)
                 {
-                    htmlCore = this.origPath + "\\" + this.htmlName + "_" + vbrOrVb365 + "_" + this.backupServerName + dateTime.ToString("_yyyy.MM.dd.HHmmss") + ".html";
+                    htmlCore = Path.Combine(this.origPath, this.htmlName + "_" + vbrOrVb365 + "_" + this.backupServerName + dateTime.ToString("_yyyy.MM.dd.HHmmss") + ".html");
 
                     // log.Warning("htmlcore = " + htmlCore, false);
                 }

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelper.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelper.cs
@@ -135,11 +135,21 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Su
             this.LogJobSessionParseProgress(100, 100);
         }
 
+        /// <summary>
+        /// CVariables.safeSuffix/unsafeSuffix and folderName are all @"\..." literals
+        /// (written assuming Windows is always the separator), so TrimStart before
+        /// handing them to Path.Combine to build a genuinely cross-platform path.
+        /// </summary>
+        private static string BuildReportDir(string suffix, string folderName)
+        {
+            return Path.Combine(CGlobals.desiredPath, suffix.TrimStart('\\'), folderName.TrimStart('\\'));
+        }
+
         private void CleanFolder(string folderName)
         {
             try
             {
-                var mainDir = CGlobals.desiredPath + CVariables.unsafeSuffix + folderName;
+                var mainDir = BuildReportDir(CVariables.unsafeSuffix, folderName);
                 if (Directory.Exists(mainDir))
                 {
                     foreach (var f in Directory.GetFiles(mainDir, "*.html"))
@@ -149,7 +159,7 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Su
                     }
                 }
 
-                var scrubDir = CGlobals.desiredPath + CVariables.safeSuffix + folderName;
+                var scrubDir = BuildReportDir(CVariables.safeSuffix, folderName);
                 if (Directory.Exists(scrubDir))
                 {
                     foreach (var f in Directory.GetFiles(scrubDir, "*.html"))
@@ -167,38 +177,34 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Su
 
         private string SetMainDir(string folderName, CJobSessionInfo cs)
         {
-            var mainDir = CGlobals.desiredPath + CVariables.unsafeSuffix + folderName;
+            var mainDir = BuildReportDir(CVariables.unsafeSuffix, folderName);
             CheckFolderExists(mainDir);
-            mainDir += "\\" + cs.JobName + ".html";
-            return mainDir;
+            return Path.Combine(mainDir, cs.JobName + ".html");
         }
 
         private string SetScrubDir(string folderName, CJobSessionInfo cs)
         {
-            var scrubDir = CGlobals.desiredPath + CVariables.safeSuffix + folderName;
+            var scrubDir = BuildReportDir(CVariables.safeSuffix, folderName);
 
             // log.Warning("SAFE outdir = " + outDir, false);
             CheckFolderExists(scrubDir);
-            scrubDir += "\\" + this.scrubber.ScrubItem(cs.JobName, ScrubItemType.Job) + ".html";
-            return scrubDir;
+            return Path.Combine(scrubDir, this.scrubber.ScrubItem(cs.JobName, ScrubItemType.Job) + ".html");
         }
 
         private string SetMainDir(string folderName, string JobName)
         {
-            var mainDir = CGlobals.desiredPath + CVariables.unsafeSuffix + folderName;
+            var mainDir = BuildReportDir(CVariables.unsafeSuffix, folderName);
             CheckFolderExists(mainDir);
-            mainDir += "\\" + SanitizeFileName(JobName) + ".html";
-            return mainDir;
+            return Path.Combine(mainDir, SanitizeFileName(JobName) + ".html");
         }
 
         private string SetScrubDir(string folderName, string JobName)
         {
-            var scrubDir = CGlobals.desiredPath + CVariables.safeSuffix + folderName;
+            var scrubDir = BuildReportDir(CVariables.safeSuffix, folderName);
 
             // log.Warning("SAFE outdir = " + outDir, false);
             CheckFolderExists(scrubDir);
-            scrubDir += "\\" + SanitizeFileName(this.scrubber.ScrubItem(JobName, ScrubItemType.Job)) + ".html";
-            return scrubDir;
+            return Path.Combine(scrubDir, SanitizeFileName(this.scrubber.ScrubItem(JobName, ScrubItemType.Job)) + ".html");
         }
 
         private static string SanitizeFileName(string name)

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelper.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelper.cs
@@ -135,14 +135,9 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Su
             this.LogJobSessionParseProgress(100, 100);
         }
 
-        /// <summary>
-        /// CVariables.safeSuffix/unsafeSuffix and folderName are all @"\..." literals
-        /// (written assuming Windows is always the separator), so TrimStart before
-        /// handing them to Path.Combine to build a genuinely cross-platform path.
-        /// </summary>
         private static string BuildReportDir(string suffix, string folderName)
         {
-            return Path.Combine(CGlobals.desiredPath, suffix.TrimStart('\\'), folderName.TrimStart('\\'));
+            return CCrossPlatformPath.Combine(CGlobals.desiredPath, suffix, folderName);
         }
 
         private void CleanFolder(string folderName)

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelper.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelper.cs
@@ -207,9 +207,12 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Su
             return Path.Combine(scrubDir, SanitizeFileName(this.scrubber.ScrubItem(JobName, ScrubItemType.Job)) + ".html");
         }
 
-        private static string SanitizeFileName(string name)
+        internal static string SanitizeFileName(string name)
         {
-            return name.Replace("\\", "--").Replace("/", "-");
+            // ':' must go too: Path.Combine(base, second) discards `base` entirely
+            // whenever `second` starts with a drive letter followed by ':'
+            // (Windows' own rooted-path rule) — e.g. a job named "C: Nightly".
+            return name.Replace("\\", "--").Replace("/", "-").Replace(":", "-");
         }
 
         private string ReturnTableHeaderString(string jobname)

--- a/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelper.cs
+++ b/vHC/HC_Reporting/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelper.cs
@@ -75,6 +75,27 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Su
             // don't linger.
             this.CleanFolder(folderName);
 
+            // mainDirBase/scrubDirBase are loop-invariant (same directory every group,
+            // since CleanFolder only deletes *.html files, never the directory itself),
+            // so create them once here instead of once per group inside SetMainDir/
+            // SetScrubDir. A failure here now skips report generation entirely (logged),
+            // rather than letting every group individually fail into a directory that
+            // doesn't exist.
+            string mainDirBase;
+            string scrubDirBase;
+            try
+            {
+                mainDirBase = BuildReportDir(CVariables.unsafeSuffix, folderName);
+                scrubDirBase = BuildReportDir(CVariables.safeSuffix, folderName);
+                CheckFolderExists(mainDirBase);
+                CheckFolderExists(scrubDirBase);
+            }
+            catch (Exception e)
+            {
+                this.log.Error("Could not create job session report output directories: " + e.Message);
+                return;
+            }
+
             var allSessions = this.ReturnJobSessionsList();
 
             // Group sessions by the same rollup key the summary table uses, so
@@ -100,8 +121,8 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Su
 
                     this.LogJobSessionParseProgress(percentCounter, totalSessions);
 
-                    string mainDir = this.SetMainDir(folderName, displayName);
-                    string scrubDir = this.SetScrubDir(folderName, displayName);
+                    string mainDir = this.SetMainDir(mainDirBase, displayName);
+                    string scrubDir = this.SetScrubDir(scrubDirBase, displayName);
 
                     string mainString = this.ReturnTableHeaderString(displayName);
                     File.WriteAllText(mainDir, mainString);
@@ -170,36 +191,14 @@ namespace VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Su
             }
         }
 
-        private string SetMainDir(string folderName, CJobSessionInfo cs)
+        private string SetMainDir(string mainDirBase, string JobName)
         {
-            var mainDir = BuildReportDir(CVariables.unsafeSuffix, folderName);
-            CheckFolderExists(mainDir);
-            return Path.Combine(mainDir, cs.JobName + ".html");
+            return Path.Combine(mainDirBase, SanitizeFileName(JobName) + ".html");
         }
 
-        private string SetScrubDir(string folderName, CJobSessionInfo cs)
+        private string SetScrubDir(string scrubDirBase, string JobName)
         {
-            var scrubDir = BuildReportDir(CVariables.safeSuffix, folderName);
-
-            // log.Warning("SAFE outdir = " + outDir, false);
-            CheckFolderExists(scrubDir);
-            return Path.Combine(scrubDir, this.scrubber.ScrubItem(cs.JobName, ScrubItemType.Job) + ".html");
-        }
-
-        private string SetMainDir(string folderName, string JobName)
-        {
-            var mainDir = BuildReportDir(CVariables.unsafeSuffix, folderName);
-            CheckFolderExists(mainDir);
-            return Path.Combine(mainDir, SanitizeFileName(JobName) + ".html");
-        }
-
-        private string SetScrubDir(string folderName, string JobName)
-        {
-            var scrubDir = BuildReportDir(CVariables.safeSuffix, folderName);
-
-            // log.Warning("SAFE outdir = " + outDir, false);
-            CheckFolderExists(scrubDir);
-            return Path.Combine(scrubDir, SanitizeFileName(this.scrubber.ScrubItem(JobName, ScrubItemType.Job)) + ".html");
+            return Path.Combine(scrubDirBase, SanitizeFileName(this.scrubber.ScrubItem(JobName, ScrubItemType.Job)) + ".html");
         }
 
         internal static string SanitizeFileName(string name)

--- a/vHC/HC_Reporting/Shared/CCrossPlatformPath.cs
+++ b/vHC/HC_Reporting/Shared/CCrossPlatformPath.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using System.Linq;
+
+namespace VeeamHealthCheck.Shared
+{
+    internal static class CCrossPlatformPath
+    {
+        /// <summary>
+        /// Path.Combine, but strips a leading '\' or '/' from each segment first, since
+        /// much of this codebase's path fragments are @"\..." literals written assuming
+        /// Windows is always the separator (Path.Combine treats a leading separator as an
+        /// absolute-path anchor and silently discards everything before it).
+        /// Callers must pass trusted, relative literal segments — this does not sanitize
+        /// untrusted/user-controlled input (e.g. job names; see
+        /// IndividualJobSessionsHelper.SanitizeFileName for that).
+        /// </summary>
+        internal static string Combine(string basePath, params string[] segments)
+        {
+            var trimmed = segments.Select(s => s.TrimStart('\\', '/'));
+            return Path.Combine(new[] { basePath }.Concat(trimmed).ToArray());
+        }
+    }
+}

--- a/vHC/HC_Reporting/Startup/CAdminCheck.cs
+++ b/vHC/HC_Reporting/Startup/CAdminCheck.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
 // MIT License
 using System;
+using System.Security.Principal;
 
 namespace VeeamHealthCheck
 {
@@ -8,7 +9,9 @@ namespace VeeamHealthCheck
     {
         public bool IsAdmin()
         {
-            return Environment.IsPrivilegedProcess;
+            return OperatingSystem.IsWindows()
+                ? new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator)
+                : Environment.IsPrivilegedProcess;
         }
     }
 }

--- a/vHC/HC_Reporting/Startup/CAdminCheck.cs
+++ b/vHC/HC_Reporting/Startup/CAdminCheck.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
 // MIT License
-using System.Security.Principal;
+using System;
 
 namespace VeeamHealthCheck
 {
@@ -8,12 +8,7 @@ namespace VeeamHealthCheck
     {
         public bool IsAdmin()
         {
-            using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
-            {
-                WindowsPrincipal principal = new WindowsPrincipal(identity);
-                bool IsAdmin = principal.IsInRole(WindowsBuiltInRole.Administrator);
-                return IsAdmin;
-            }
+            return Environment.IsPrivilegedProcess;
         }
     }
 }

--- a/vHC/HC_Reporting/Startup/CArgsParser.cs
+++ b/vHC/HC_Reporting/Startup/CArgsParser.cs
@@ -84,7 +84,10 @@ namespace VeeamHealthCheck.Startup
 
         private IntPtr Handle()
         {
-            return GetConsoleWindow();
+            // GetConsoleWindow is a kernel32.dll P/Invoke — no console-window
+            // concept exists off Windows, so calling it there would throw
+            // DllNotFoundException.
+            return OperatingSystem.IsWindows() ? GetConsoleWindow() : IntPtr.Zero;
         }
 
         // private int ParseZeroArgs()

--- a/vHC/HC_Reporting/Startup/CArgsParser.cs
+++ b/vHC/HC_Reporting/Startup/CArgsParser.cs
@@ -113,6 +113,8 @@ namespace VeeamHealthCheck.Startup
             bool runHfd = false;
             string _hfdPath = string.Empty;
 
+            // Same intentional Windows-only default as CVariables.outDir - see that
+            // comment for why this isn't cross-platform-guarded.
             string targetDir = @"C:\temp\vHC";
             foreach (var a in args)
             {

--- a/vHC/HC_Reporting/Startup/CArgsParser.cs
+++ b/vHC/HC_Reporting/Startup/CArgsParser.cs
@@ -237,13 +237,9 @@ namespace VeeamHealthCheck.Startup
                             CGlobals.TargetProductType = TargetProduct.Vb365;
                         CGlobals.Logger.Info("Target product: VB365", false);
                         break;
-                    case var match when new Regex("/path=.*").IsMatch(a):
+                    case var match when new Regex("/path=.*", RegexOptions.IgnoreCase).IsMatch(a):
                         _hfdPath = this.ParsePath(a);
-                        CGlobals.Logger.Info("HFD path: " + targetDir);
-                        break;
-                    case var match when new Regex("/PATH=.*").IsMatch(a):
-                        _hfdPath = this.ParsePath(a);
-                        CGlobals.Logger.Info("HFD path: " + targetDir);
+                        CGlobals.Logger.Info("HFD path: " + _hfdPath);
                         break;
                     case var match when new Regex("/outdir=.*", RegexOptions.IgnoreCase).IsMatch(a):
                         string parsedOutDir = this.ParsePath(a);

--- a/vHC/HC_Reporting/Startup/CVariables.cs
+++ b/vHC/HC_Reporting/Startup/CVariables.cs
@@ -52,7 +52,7 @@ namespace VeeamHealthCheck
                     return CGlobals.IMPORT_PATH;
                 }
 
-                return unsafeDir + vb365Dir;
+                return CCrossPlatformPath.Combine(unsafeDir, vb365Dir);
             }
         }
 
@@ -83,7 +83,7 @@ namespace VeeamHealthCheck
         /// </summary>
         private static string GetVbrDirWithTimestamp()
         {
-            string basePath = unsafeDir + VbrDir;
+            string basePath = CCrossPlatformPath.Combine(unsafeDir, VbrDir);
 
             // Get server name - prefer REMOTEHOST (set from /host= in CLI mode), fall back to VBRServerName (GUI), then "localhost"
             string serverName = !string.IsNullOrEmpty(CGlobals.REMOTEHOST)
@@ -105,7 +105,7 @@ namespace VeeamHealthCheck
         /// </summary>
         public static string GetVbrBaseDir()
         {
-            return unsafeDir + VbrDir;
+            return CCrossPlatformPath.Combine(unsafeDir, VbrDir);
         }
 
         /// <summary>

--- a/vHC/HC_Reporting/Startup/CVariables.cs
+++ b/vHC/HC_Reporting/Startup/CVariables.cs
@@ -8,6 +8,11 @@ namespace VeeamHealthCheck
 {
     public class CVariables
     {
+        // Intentionally a Windows path literal, not OperatingSystem.IsWindows()-guarded:
+        // actual collection always depends on the Windows-only Veeam.Backup.PowerShell
+        // module, so the compiled binary only ever runs on Windows for now regardless of
+        // where it's built/tested. Revisit if cross-platform execution (not just
+        // cross-platform compilation/testing) is ever expected.
         public static readonly string outDir = @"C:\temp\vHC";
 
         // Use CGlobals.desiredPath as the base, falling back to the default if not set

--- a/vHC/HC_Reporting/Startup/CredentialStore.cs
+++ b/vHC/HC_Reporting/Startup/CredentialStore.cs
@@ -229,29 +229,31 @@ public static class CredentialStore
         {
             if (_cache.Remove(server))
             {
-                // Update the file with remaining credentials
-                var serializable = _cache.ToDictionary(
-                    kvp => kvp.Key,
-                    kvp => new CredentialRecord
-                    {
-                        Username = kvp.Value.Username,
-                        PasswordEnc = Convert.ToBase64String(kvp.Value.PasswordEnc)
-                    });
+                // Sync the on-disk file (if any) to match, by removing the key
+                // from whatever is actually there rather than re-serializing
+                // _cache: on non-Windows, Set() keeps unprotected password bytes
+                // in _cache without ever persisting them (see Set()), so writing
+                // _cache back out could leak those. Editing the file's own
+                // contents in place never introduces anything that wasn't
+                // already safely on disk, and works the same on every OS.
+                if (File.Exists(StorePath))
+                {
+                    var json = File.ReadAllText(StorePath);
+                    var dict = string.IsNullOrWhiteSpace(json)
+                        ? null
+                        : JsonSerializer.Deserialize<Dictionary<string, CredentialRecord>>(json);
 
-                if (_cache.Count == 0)
-                {
-                    // If no credentials left, delete the file
-                    if (File.Exists(StorePath))
+                    if (dict != null && dict.Remove(server))
                     {
-                        File.Delete(StorePath);
+                        if (dict.Count == 0)
+                        {
+                            File.Delete(StorePath);
+                        }
+                        else
+                        {
+                            File.WriteAllText(StorePath, JsonSerializer.Serialize(dict, new JsonSerializerOptions { WriteIndented = true }));
+                        }
                     }
-                }
-                else if (OperatingSystem.IsWindows())
-                {
-                    // Write remaining credentials back to file. Off Windows, Set()
-                    // never wrote these to disk in the first place (see Set()), so
-                    // there is nothing to rewrite there.
-                    File.WriteAllText(StorePath, JsonSerializer.Serialize(serializable, new JsonSerializerOptions { WriteIndented = true }));
                 }
 
                 CGlobals.Logger.Info($"Removed credentials for server: {server}");

--- a/vHC/HC_Reporting/Startup/CredentialStore.cs
+++ b/vHC/HC_Reporting/Startup/CredentialStore.cs
@@ -26,6 +26,10 @@ public static class CredentialStore
 
     private static Dictionary<string, (string Username, byte[] PasswordEnc)> _cache;
 
+    // Keys set via SetTransient() this run that must never be persisted, even when
+    // an unrelated Set() call for a different server triggers a disk write.
+    private static readonly HashSet<string> _transientKeys = new();
+
     static CredentialStore()
     {
         InitializeCache();
@@ -35,6 +39,7 @@ public static class CredentialStore
     {
         try
         {
+            _transientKeys.Clear();
             Directory.CreateDirectory(Path.GetDirectoryName(StorePath));
             // log the path for debugging purposes
             CGlobals.Logger.Debug($"Credential store path: {StorePath}");
@@ -108,6 +113,7 @@ public static class CredentialStore
         try
         {
             _cache = new Dictionary<string, (string, byte[])>();
+            _transientKeys.Clear();
 
             if (File.Exists(StorePath))
             {
@@ -160,6 +166,7 @@ public static class CredentialStore
     public static void Set(string server, string username, string password)
     {
         SetCache(server, username, password);
+        _transientKeys.Remove(server); // an explicit Set() for this server means "persist it now"
 
         if (OperatingSystem.IsWindows())
         {
@@ -176,11 +183,14 @@ public static class CredentialStore
     /// Stores credentials in the in-memory cache only — does NOT write to the
     /// DPAPI-encrypted creds.json on disk. Used by the /credfile= loader to
     /// populate transient credentials for the lifetime of the current process
-    /// without leaving anything behind on disk.
+    /// without leaving anything behind on disk. Marked so that a later, unrelated
+    /// Set() call for a different server (which persists the whole cache) can never
+    /// carry this entry to disk too.
     /// </summary>
     public static void SetTransient(string server, string username, string password)
     {
         SetCache(server, username, password);
+        _transientKeys.Add(server);
     }
 
     /// <summary>
@@ -197,20 +207,52 @@ public static class CredentialStore
     }
 
     /// <summary>
-    /// Internal: serialize the in-memory cache to the on-disk creds.json.
-    /// Only Set() (and not SetTransient) calls this.
+    /// Pure merge logic behind PersistCacheToDisk: upsert every non-transient _cache
+    /// entry into the existing on-disk dict, leaving transient entries and any other
+    /// pre-existing disk entries untouched. Never overwrite wholesale with a filtered
+    /// _cache -- a host that's both already-persisted on disk AND marked transient
+    /// this run (e.g. it also appears in a /credfile=) would otherwise have its
+    /// legitimately-persisted disk record silently deleted by the next unrelated
+    /// Set() call.
     /// </summary>
-    private static void PersistCacheToDisk()
+    internal static Dictionary<string, CredentialRecord> MergePersistablePayload(
+        Dictionary<string, CredentialRecord> existingOnDisk,
+        IReadOnlyDictionary<string, (string Username, byte[] PasswordEnc)> cache,
+        ISet<string> transientKeys)
     {
-        var serializable = _cache.ToDictionary(
-            kvp => kvp.Key,
-            kvp => new CredentialRecord
+        var result = new Dictionary<string, CredentialRecord>(existingOnDisk);
+        foreach (var kvp in cache)
+        {
+            if (transientKeys.Contains(kvp.Key))
+                continue;
+
+            result[kvp.Key] = new CredentialRecord
             {
                 Username = kvp.Value.Username,
                 PasswordEnc = Convert.ToBase64String(kvp.Value.PasswordEnc)
-            });
+            };
+        }
+        return result;
+    }
 
-        File.WriteAllText(StorePath, JsonSerializer.Serialize(serializable, new JsonSerializerOptions { WriteIndented = true }));
+    /// <summary>
+    /// Internal: merge the in-memory cache's non-transient entries into the on-disk
+    /// creds.json. Only Set() (and not SetTransient) calls this.
+    /// </summary>
+    private static void PersistCacheToDisk()
+    {
+        Dictionary<string, CredentialRecord> onDisk = new();
+        if (File.Exists(StorePath))
+        {
+            var json = File.ReadAllText(StorePath);
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                onDisk = JsonSerializer.Deserialize<Dictionary<string, CredentialRecord>>(json) ?? new();
+            }
+        }
+
+        var merged = MergePersistablePayload(onDisk, _cache, _transientKeys);
+        File.WriteAllText(StorePath, JsonSerializer.Serialize(merged, new JsonSerializerOptions { WriteIndented = true }));
     }
 
     /// <summary>
@@ -232,6 +274,8 @@ public static class CredentialStore
         {
             if (_cache.Remove(server))
             {
+                _transientKeys.Remove(server);
+
                 // Sync the on-disk file (if any) to match, by removing the key
                 // from whatever is actually there rather than re-serializing
                 // _cache: on non-Windows, Set() keeps unprotected password bytes

--- a/vHC/HC_Reporting/Startup/CredentialStore.cs
+++ b/vHC/HC_Reporting/Startup/CredentialStore.cs
@@ -17,7 +17,10 @@ public class CredentialRecord
 
 public static class CredentialStore
 {
-    private static readonly string StorePath = Path.Combine(
+    // Internal + settable so tests can point this at an isolated temp path instead
+    // of the real %APPDATA%/VeeamHealthCheck/creds.json. Production code never sets
+    // this; the default preserves real behavior exactly.
+    internal static string StorePath { get; set; } = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
         "VeeamHealthCheck", "creds.json");
 
@@ -28,7 +31,7 @@ public static class CredentialStore
         InitializeCache();
     }
 
-    private static void InitializeCache()
+    internal static void InitializeCache()
     {
         try
         {

--- a/vHC/HC_Reporting/Startup/CredentialStore.cs
+++ b/vHC/HC_Reporting/Startup/CredentialStore.cs
@@ -137,17 +137,36 @@ public static class CredentialStore
             if (val.PasswordEnc == null || val.PasswordEnc.Length == 0)
                 return null; // Prevent null/empty password decryption
 
-            var password = Encoding.UTF8.GetString(
-                ProtectedData.Unprotect(val.PasswordEnc, null, DataProtectionScope.CurrentUser));
+            var passwordBytes = OperatingSystem.IsWindows()
+                ? ProtectedData.Unprotect(val.PasswordEnc, null, DataProtectionScope.CurrentUser)
+                : val.PasswordEnc;
+            var password = Encoding.UTF8.GetString(passwordBytes);
             return (val.Username, password);
         }
         return null;
     }
 
+    /// <summary>
+    /// Stores credentials in the in-memory cache and, on Windows, persists them
+    /// DPAPI-encrypted to disk. DPAPI has no cross-platform equivalent, so on
+    /// macOS/Linux this only keeps the credential for the lifetime of the
+    /// current process — see <see cref="SetTransient"/> for the always-in-memory
+    /// case. We never write the raw (non-DPAPI) bytes to disk, to avoid silently
+    /// persisting credentials unencrypted.
+    /// </summary>
     public static void Set(string server, string username, string password)
     {
         SetCache(server, username, password);
-        PersistCacheToDisk();
+
+        if (OperatingSystem.IsWindows())
+        {
+            PersistCacheToDisk();
+        }
+        else
+        {
+            CGlobals.Logger.Warning(
+                $"Persistent credential storage requires Windows (DPAPI); credentials for '{server}' will only be kept for this session.");
+        }
     }
 
     /// <summary>
@@ -167,8 +186,10 @@ public static class CredentialStore
     /// </summary>
     private static void SetCache(string server, string username, string password)
     {
-        var enc = ProtectedData.Protect(
-            Encoding.UTF8.GetBytes(password), null, DataProtectionScope.CurrentUser);
+        var passwordBytes = Encoding.UTF8.GetBytes(password);
+        var enc = OperatingSystem.IsWindows()
+            ? ProtectedData.Protect(passwordBytes, null, DataProtectionScope.CurrentUser)
+            : passwordBytes;
         _cache[server] = (username, enc);
     }
 
@@ -225,9 +246,11 @@ public static class CredentialStore
                         File.Delete(StorePath);
                     }
                 }
-                else
+                else if (OperatingSystem.IsWindows())
                 {
-                    // Write remaining credentials back to file
+                    // Write remaining credentials back to file. Off Windows, Set()
+                    // never wrote these to disk in the first place (see Set()), so
+                    // there is nothing to rewrite there.
                     File.WriteAllText(StorePath, JsonSerializer.Serialize(serializable, new JsonSerializerOptions { WriteIndented = true }));
                 }
 

--- a/vHC/VhcXTests/CAdminCheckTests.cs
+++ b/vHC/VhcXTests/CAdminCheckTests.cs
@@ -1,0 +1,18 @@
+using VeeamHealthCheck;
+using Xunit;
+
+namespace VhcXTests
+{
+    public class CAdminCheckTests
+    {
+        [Fact]
+        public void IsAdmin_AnyOperatingSystem_DoesNotThrow()
+        {
+            var check = new CAdminCheck();
+
+            var exception = Record.Exception(() => check.IsAdmin());
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/vHC/VhcXTests/CRegReaderTests.cs
+++ b/vHC/VhcXTests/CRegReaderTests.cs
@@ -21,7 +21,7 @@ namespace VhcXTests
         private const string DefaultConsolePath =
             @"C:\Program Files\Veeam\Backup and Replication\Console\Veeam.Backup.Core.dll";
 
-        [Fact]
+        [WindowsOnlyFact]
         public void GetVbrVersionFilePath_NoLocalConsoleAndNoMountServiceKey_ReturnsNullInsteadOfThrowing()
         {
             // This regression guard only applies on a machine without VBR/Mount Service

--- a/vHC/VhcXTests/CScrubHandlerSecurityTests.cs
+++ b/vHC/VhcXTests/CScrubHandlerSecurityTests.cs
@@ -109,7 +109,7 @@ namespace VhcXTests
 
         // ---- RestrictFileToOwner (ACL lockdown) -------------------------
 
-        [Fact]
+        [WindowsOnlyFact]
         public void RestrictFileToOwner_RemovesBroadAccessAndBreaksInheritance()
         {
             string path = Path.Combine(Path.GetTempPath(), $"vhc-keyfile-acl-{System.Guid.NewGuid():N}.json");

--- a/vHC/VhcXTests/CredentialStoreSecurityTests.cs
+++ b/vHC/VhcXTests/CredentialStoreSecurityTests.cs
@@ -452,12 +452,16 @@ namespace VeeamHealthCheck.Tests.Security
             // Act
             CredentialStore.Set(server, username, password);
 
-            var storePath = CredentialStore.StorePath;
+            // Assert - Set() persisted somewhere (the isolated test store, in this suite)
+            Assert.True(File.Exists(CredentialStore.StorePath));
 
-            // Assert - File should be in user's AppData
-            Assert.True(File.Exists(storePath));
-            Assert.Contains("AppData", storePath);
-            Assert.Contains("VeeamHealthCheck", storePath);
+            // Assert - the real production default (captured in the constructor
+            // before this class's isolation seam overrides it) lives under the
+            // user's profile in a VeeamHealthCheck folder. Asserting against
+            // _originalStorePath rather than CredentialStore.StorePath here since
+            // the latter is intentionally overridden to a temp path for this suite.
+            Assert.Contains("AppData", _originalStorePath);
+            Assert.Contains("VeeamHealthCheck", _originalStorePath);
 
             // Cleanup
             CredentialStore.Clear();

--- a/vHC/VhcXTests/CredentialStoreSecurityTests.cs
+++ b/vHC/VhcXTests/CredentialStoreSecurityTests.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using Xunit;
 using VeeamHealthCheck.Startup;
 using VeeamHealthCheck.Shared;
+using VhcXTests;
 
 namespace VeeamHealthCheck.Tests.Security
 {
@@ -45,7 +46,7 @@ namespace VeeamHealthCheck.Tests.Security
             }
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void StoredCredentials_ShouldBeEncrypted()
         {
             // Arrange
@@ -78,7 +79,7 @@ namespace VeeamHealthCheck.Tests.Security
             CredentialStore.Clear();
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void StoredCredentials_ShouldNotContainPlaintextPassword()
         {
             // Arrange
@@ -135,7 +136,7 @@ namespace VeeamHealthCheck.Tests.Security
             CredentialStore.Clear();
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void Set_WithComplexPassword_ShouldEncryptAndDecryptCorrectly()
         {
             // Arrange - Test various special characters
@@ -223,7 +224,7 @@ namespace VeeamHealthCheck.Tests.Security
             CredentialStore.Clear();
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void Clear_ShouldRemoveAllCredentialsAndFile()
         {
             // Arrange
@@ -248,7 +249,7 @@ namespace VeeamHealthCheck.Tests.Security
             Assert.False(CredentialStore.HasStoredCredentials());
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void MultipleServers_ShouldStoreSeparateEncryptedCredentials()
         {
             // Arrange
@@ -290,7 +291,7 @@ namespace VeeamHealthCheck.Tests.Security
             CredentialStore.Clear();
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void PasswordEncryption_ShouldBeUniquePerPassword()
         {
             // Arrange
@@ -354,7 +355,7 @@ namespace VeeamHealthCheck.Tests.Security
             Assert.False(removed);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void CredentialFile_ShouldBeInUserProfile()
         {
             // Arrange

--- a/vHC/VhcXTests/CredentialStoreSecurityTests.cs
+++ b/vHC/VhcXTests/CredentialStoreSecurityTests.cs
@@ -1,8 +1,11 @@
 // Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
 // MIT License
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Xunit;
 using VeeamHealthCheck.Startup;
@@ -219,6 +222,49 @@ namespace VeeamHealthCheck.Tests.Security
                 string fileContent = File.ReadAllText(storePath);
                 Assert.DoesNotContain(server, fileContent, StringComparison.Ordinal);
             }
+
+            // Cleanup
+            CredentialStore.Clear();
+        }
+
+        [Fact]
+        public void Remove_WhenOtherCredentialsRemainOnDisk_ShouldRemoveEntryFromFileRegardlessOfOS()
+        {
+            // Arrange
+            string serverA = "remove-sync-test-a.local";
+            string serverB = "remove-sync-test-b.local";
+            var storePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "VeeamHealthCheck", "creds.json");
+
+            CredentialStore.Clear();
+
+            // Populate the in-memory cache for both servers. Set() always updates
+            // the cache; on non-Windows it does NOT persist to disk (DPAPI is
+            // unavailable there), so _cache and the on-disk file can diverge.
+            CredentialStore.Set(serverA, "userA", "pfake-A");
+            CredentialStore.Set(serverB, "userB", "pfake-B");
+
+            // Simulate a creds.json that already has both entries on disk, e.g.
+            // written by a prior run on Windows and then loaded here by
+            // InitializeCache() on any OS.
+            var onDisk = new Dictionary<string, CredentialRecord>
+            {
+                [serverA] = new CredentialRecord { Username = "userA", PasswordEnc = Convert.ToBase64String(Encoding.UTF8.GetBytes("fakeA")) },
+                [serverB] = new CredentialRecord { Username = "userB", PasswordEnc = Convert.ToBase64String(Encoding.UTF8.GetBytes("fakeB")) },
+            };
+            File.WriteAllText(storePath, JsonSerializer.Serialize(onDisk, new JsonSerializerOptions { WriteIndented = true }));
+
+            // Act
+            bool removed = CredentialStore.Remove(serverA);
+
+            // Assert
+            Assert.True(removed);
+            Assert.True(File.Exists(storePath), "creds.json should still exist since serverB's credentials remain.");
+
+            string fileContent = File.ReadAllText(storePath);
+            Assert.DoesNotContain(serverA, fileContent, StringComparison.Ordinal);
+            Assert.Contains(serverB, fileContent, StringComparison.Ordinal);
 
             // Cleanup
             CredentialStore.Clear();

--- a/vHC/VhcXTests/CredentialStoreSecurityTests.cs
+++ b/vHC/VhcXTests/CredentialStoreSecurityTests.cs
@@ -266,6 +266,56 @@ namespace VeeamHealthCheck.Tests.Security
             CredentialStore.Clear();
         }
 
+        [Fact]
+        public void MergePersistablePayload_ExistingDiskEntryMarkedTransientInCache_KeepsOriginalDiskEntryUnchanged()
+        {
+            // A host can be both already-persisted on disk from a prior run AND
+            // marked transient in the current run's cache (e.g. it also appears in
+            // a /credfile= this run). Persisting must not let the transient marker
+            // delete or overwrite that host's legitimately-persisted disk record --
+            // only entries that are NOT transient should be written/updated.
+            var existingOnDisk = new Dictionary<string, CredentialRecord>
+            {
+                ["hostA"] = new CredentialRecord { Username = "diskUserA", PasswordEnc = "diskEncA" },
+            };
+            var cache = new Dictionary<string, (string Username, byte[] PasswordEnc)>
+            {
+                ["hostA"] = ("cacheUserA", Encoding.UTF8.GetBytes("cacheRawA")), // transient this run
+                ["hostB"] = ("userB", Encoding.UTF8.GetBytes("rawB")), // not transient
+            };
+            var transientKeys = new HashSet<string> { "hostA" };
+
+            var result = CredentialStore.MergePersistablePayload(existingOnDisk, cache, transientKeys);
+
+            Assert.True(result.ContainsKey("hostA"));
+            Assert.Equal("diskUserA", result["hostA"].Username);
+            Assert.Equal("diskEncA", result["hostA"].PasswordEnc);
+
+            Assert.True(result.ContainsKey("hostB"));
+            Assert.Equal("userB", result["hostB"].Username);
+            Assert.Equal(Convert.ToBase64String(Encoding.UTF8.GetBytes("rawB")), result["hostB"].PasswordEnc);
+        }
+
+        [WindowsOnlyFact]
+        public void SetTransient_ThenSetForDifferentHost_DoesNotPersistTransientHostToDisk()
+        {
+            // Reproduces the /credfile= -> interactive-prompt-for-a-different-host
+            // path: LoadCredFile seeds transient hosts via SetTransient, then later
+            // in the same process a Set() call for an unrelated host must not
+            // persist the transient hosts to disk too.
+            string transientHost = "credfile-transient-host.local";
+            string persistedHost = "interactive-persisted-host.local";
+
+            CredentialStore.SetTransient(transientHost, "userT", "pfake-T");
+            CredentialStore.Set(persistedHost, "userP", "pfake-P");
+
+            string fileContent = File.ReadAllText(CredentialStore.StorePath);
+            Assert.DoesNotContain(transientHost, fileContent, StringComparison.Ordinal);
+            Assert.Contains(persistedHost, fileContent, StringComparison.Ordinal);
+
+            CredentialStore.Clear();
+        }
+
         [WindowsOnlyFact]
         public void Clear_ShouldRemoveAllCredentialsAndFile()
         {

--- a/vHC/VhcXTests/CredentialStoreSecurityTests.cs
+++ b/vHC/VhcXTests/CredentialStoreSecurityTests.cs
@@ -14,7 +14,7 @@ using VhcXTests;
 
 namespace VeeamHealthCheck.Tests.Security
 {
-    [Collection("Credential Store Tests")]
+    [Collection("GlobalState")]
     [Trait("Category", "Security")]
     public class CredentialStoreSecurityTests : IDisposable
     {

--- a/vHC/VhcXTests/CredentialStoreSecurityTests.cs
+++ b/vHC/VhcXTests/CredentialStoreSecurityTests.cs
@@ -23,18 +23,24 @@ namespace VeeamHealthCheck.Tests.Security
 
         public CredentialStoreSecurityTests()
         {
-            // Create a temporary directory for test credential storage
+            _originalStorePath = CredentialStore.StorePath;
+
+            // Create a temporary directory for test credential storage, and point
+            // CredentialStore at a creds.json inside it instead of the real
+            // %APPDATA%/VeeamHealthCheck/creds.json, so these tests never touch a
+            // real user's stored credentials.
             _testStorePath = Path.Combine(Path.GetTempPath(), $"vhc-creds-test-{Guid.NewGuid()}");
             Directory.CreateDirectory(_testStorePath);
-            
-            // Store original path to restore later (if needed)
-            _originalStorePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+
+            CredentialStore.StorePath = Path.Combine(_testStorePath, "creds.json");
+            CredentialStore.InitializeCache();
         }
 
         public void Dispose()
         {
+            CredentialStore.StorePath = _originalStorePath;
+            CredentialStore.InitializeCache();
+
             // Clean up test directory
             if (Directory.Exists(_testStorePath))
             {
@@ -61,9 +67,7 @@ namespace VeeamHealthCheck.Tests.Security
             CredentialStore.Set(server, username, password);
 
             // Read the raw file content
-            var storePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+            var storePath = CredentialStore.StorePath;
             
             string fileContent = File.ReadAllText(storePath);
 
@@ -94,9 +98,7 @@ namespace VeeamHealthCheck.Tests.Security
             CredentialStore.Set(server, username, password);
 
             // Read the raw file
-            var storePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+            var storePath = CredentialStore.StorePath;
             
             string fileContent = File.ReadAllText(storePath);
 
@@ -156,9 +158,7 @@ namespace VeeamHealthCheck.Tests.Security
             Assert.Equal(complexPassword, retrieved.Value.Password);
 
             // Verify file doesn't contain plaintext
-            var storePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+            var storePath = CredentialStore.StorePath;
             
             string fileContent = File.ReadAllText(storePath);
             Assert.DoesNotContain(complexPassword, fileContent, StringComparison.Ordinal);
@@ -213,9 +213,7 @@ namespace VeeamHealthCheck.Tests.Security
             Assert.Null(CredentialStore.Get(server));
 
             // Verify file doesn't contain the server name anymore
-            var storePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+            var storePath = CredentialStore.StorePath;
 
             if (File.Exists(storePath))
             {
@@ -233,9 +231,7 @@ namespace VeeamHealthCheck.Tests.Security
             // Arrange
             string serverA = "remove-sync-test-a.local";
             string serverB = "remove-sync-test-b.local";
-            var storePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+            var storePath = CredentialStore.StorePath;
 
             CredentialStore.Clear();
 
@@ -278,9 +274,7 @@ namespace VeeamHealthCheck.Tests.Security
             CredentialStore.Set("server2.local", "user2", "pass2");
             CredentialStore.Set("server3.local", "user3", "pass3");
 
-            var storePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+            var storePath = CredentialStore.StorePath;
 
             Assert.True(File.Exists(storePath));
 
@@ -322,9 +316,7 @@ namespace VeeamHealthCheck.Tests.Security
             }
 
             // Verify file doesn't contain any plaintext passwords
-            var storePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+            var storePath = CredentialStore.StorePath;
             
             string fileContent = File.ReadAllText(storePath);
 
@@ -352,9 +344,7 @@ namespace VeeamHealthCheck.Tests.Security
             CredentialStore.Set(server2, username, password2);
 
             // Read raw file
-            var storePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+            var storePath = CredentialStore.StorePath;
             
             string fileContent = File.ReadAllText(storePath);
 
@@ -412,9 +402,7 @@ namespace VeeamHealthCheck.Tests.Security
             // Act
             CredentialStore.Set(server, username, password);
 
-            var storePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "VeeamHealthCheck", "creds.json");
+            var storePath = CredentialStore.StorePath;
 
             // Assert - File should be in user's AppData
             Assert.True(File.Exists(storePath));

--- a/vHC/VhcXTests/Functions/Reporting/Html/CHtmlExporterTEST.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/CHtmlExporterTEST.cs
@@ -60,8 +60,8 @@ namespace VhcXTests.Functions.Reporting.Html
 
             // Assert
             Assert.True(Directory.Exists(CGlobals.desiredPath));
-            Assert.True(Directory.Exists(CGlobals.desiredPath + CVariables.safeSuffix));
-            Assert.True(Directory.Exists(CGlobals.desiredPath + CVariables.unsafeSuffix));
+            Assert.True(Directory.Exists(Path.Combine(CGlobals.desiredPath, CVariables.safeSuffix.TrimStart('\\'))));
+            Assert.True(Directory.Exists(Path.Combine(CGlobals.desiredPath, CVariables.unsafeSuffix.TrimStart('\\'))));
         }
 
         [Fact]

--- a/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelperTests.cs
+++ b/vHC/VhcXTests/Functions/Reporting/Html/VBR/VbrTables/Job Session Summary/IndividualJobSessionsHelperTests.cs
@@ -1,0 +1,29 @@
+using VeeamHealthCheck.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Summary;
+using Xunit;
+
+namespace VhcXTests.Functions.Reporting.Html.VBR.VbrTables.Job_Session_Summary
+{
+    public class IndividualJobSessionsHelperTests
+    {
+        [Theory]
+        [InlineData("C: Nightly Backup")]
+        [InlineData("d:report")]
+        [InlineData("Z:")]
+        public void SanitizeFileName_JobNameLooksLikeWindowsDriveLetter_StripsColonSoPathCombineCannotEscape(string jobName)
+        {
+            string sanitized = IndividualJobSessionsHelper.SanitizeFileName(jobName);
+
+            // Path.Combine(basePath, second) silently discards basePath whenever
+            // `second` looks like a Windows drive-rooted segment: a single letter
+            // followed by ':'. Assert against that exact rule rather than
+            // Path.IsPathRooted, since IsPathRooted's drive-letter check is
+            // Windows-only behavior and this suite also runs on macOS/Linux.
+            bool looksLikeWindowsRootedDriveSegment =
+                sanitized.Length >= 2 && char.IsLetter(sanitized[0]) && sanitized[1] == ':';
+
+            Assert.False(
+                looksLikeWindowsRootedDriveSegment,
+                $"Sanitized name '{sanitized}' would still be treated as a rooted path segment by Path.Combine on Windows.");
+        }
+    }
+}

--- a/vHC/VhcXTests/GlobalStateCollection.cs
+++ b/vHC/VhcXTests/GlobalStateCollection.cs
@@ -6,7 +6,8 @@ namespace VhcXTests
 {
     // Serializes every test class that mutates shared mutable static state
     // (CGlobals.desiredPath / IMPORT / IMPORT_PATH / Scrubber, CVariables.ResolvedImportPath,
-    // and the static CLogger). xUnit parallelizes test classes across threads by default,
+    // the static CLogger, and CredentialStore's static _cache/StorePath). xUnit parallelizes
+    // test classes across threads by default,
     // and the ctor/Dispose save-restore pattern only guards SEQUENTIAL leakage on one thread —
     // it cannot stop a concurrent thread mutating the same statics. Placing all such classes in
     // this single DisableParallelization collection makes the suite deterministic without

--- a/vHC/VhcXTests/Integration/PSScriptIntegrationTests.cs
+++ b/vHC/VhcXTests/Integration/PSScriptIntegrationTests.cs
@@ -27,7 +27,7 @@ namespace VhcXTests.Integration
 
         private static int RunPwshAndLog(ProcessStartInfo psi, string logName)
         {
-            Directory.CreateDirectory("TestResults\\pwsh-logs");
+            Directory.CreateDirectory(Path.Combine("TestResults", "pwsh-logs"));
 
             using var process = Process.Start(psi);
             if (process == null)

--- a/vHC/VhcXTests/PathValidationTests.cs
+++ b/vHC/VhcXTests/PathValidationTests.cs
@@ -62,7 +62,7 @@ namespace VhcXTests
             Assert.False(result);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void VerifyPath_WhitespacePath_ReturnsFalse()
         {
             // Arrange
@@ -143,7 +143,7 @@ namespace VhcXTests
             Assert.True(Directory.Exists(path));
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void VerifyPath_InvalidCharacters_ReturnsFalse()
         {
             // Arrange

--- a/vHC/VhcXTests/Shared/CCrossPlatformPathTests.cs
+++ b/vHC/VhcXTests/Shared/CCrossPlatformPathTests.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using VeeamHealthCheck.Shared;
+using Xunit;
+
+namespace VhcXTests.Shared
+{
+    public class CCrossPlatformPathTests
+    {
+        [Fact]
+        public void Combine_SegmentsWithLeadingBackslash_StripsBackslashBeforeJoining()
+        {
+            string result = CCrossPlatformPath.Combine("/base", @"\vHC-Report", @"\JobSessionReports");
+
+            Assert.Equal(Path.Combine("/base", "vHC-Report", "JobSessionReports"), result);
+        }
+
+        [Fact]
+        public void Combine_SegmentsWithLeadingForwardSlash_StripsForwardSlashBeforeJoining()
+        {
+            string result = CCrossPlatformPath.Combine("/base", "/vHC-Report", "/JobSessionReports");
+
+            Assert.Equal(Path.Combine("/base", "vHC-Report", "JobSessionReports"), result);
+        }
+
+        [Fact]
+        public void Combine_SegmentLooksLikeWindowsDriveLetter_PassesThroughUntrimmed()
+        {
+            // Documented contract: callers must pass trusted, relative literal
+            // segments. This helper only strips leading slashes/backslashes; it
+            // does not sanitize an untrusted segment that still looks rooted
+            // after trimming (e.g. "C:\evil") — that's SanitizeFileName's job
+            // for user-controlled input such as job names.
+            string result = CCrossPlatformPath.Combine("/base", @"C:\evil");
+
+            Assert.Equal(Path.Combine("/base", @"C:\evil"), result);
+        }
+    }
+}

--- a/vHC/VhcXTests/SilentModeTests.cs
+++ b/vHC/VhcXTests/SilentModeTests.cs
@@ -21,7 +21,7 @@ namespace VhcXTests
     ///
     /// Naming convention: [Method]_[Scenario]_[Expected].
     /// </summary>
-    [Collection("Credential Store Tests")]
+    [Collection("GlobalState")]
     [Trait("Category", "Silent")]
     public class SilentModeTests : IDisposable
     {

--- a/vHC/VhcXTests/Startup/CVariablesPathConcatenationTests.cs
+++ b/vHC/VhcXTests/Startup/CVariablesPathConcatenationTests.cs
@@ -1,0 +1,89 @@
+// Copyright (C) 2025 VeeamHub
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.IO;
+using VeeamHealthCheck;
+using VeeamHealthCheck.Shared;
+using Xunit;
+
+namespace VhcXTests.Startup
+{
+    /// <summary>
+    /// Guards CVariables.vb365dir/vbrDir/GetVbrBaseDir against reverting to raw '+'
+    /// string concatenation of unsafeDir (already Path.Combine-built) with the
+    /// "\VB365"/"\VBR" literals. That never breaks real Windows production
+    /// (backslash literals work fine there), but breaks the moment these getters
+    /// are exercised by tests on non-Windows CI, which is exactly what this
+    /// initiative needs to be trustworthy.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Collection("GlobalState")]
+    public class CVariablesPathConcatenationTests : IDisposable
+    {
+        private readonly string _tempDir;
+        private readonly string _origDesiredPath;
+        private readonly bool _origImport;
+        private readonly string _origImportPath;
+        private readonly string _origResolvedImportPath;
+
+        public CVariablesPathConcatenationTests()
+        {
+            _origDesiredPath = CGlobals.desiredPath;
+            _origImport = CGlobals.IMPORT;
+            _origImportPath = CGlobals.IMPORT_PATH;
+            _origResolvedImportPath = CVariables.ResolvedImportPath;
+
+            _tempDir = Path.Combine(Path.GetTempPath(), "VhcPathConcatTests_" + Guid.NewGuid());
+            Directory.CreateDirectory(_tempDir);
+
+            CGlobals.desiredPath = _tempDir;
+
+            // Explicitly fall through to the non-import branch: vb365dir/vbrDir check
+            // CGlobals.IMPORT first, and the raw-concatenation bug only lives in the
+            // non-import branch.
+            CGlobals.IMPORT = false;
+            CGlobals.IMPORT_PATH = null;
+            CVariables.ResolvedImportPath = null;
+        }
+
+        public void Dispose()
+        {
+            CGlobals.desiredPath = _origDesiredPath;
+            CGlobals.IMPORT = _origImport;
+            CGlobals.IMPORT_PATH = _origImportPath;
+            CVariables.ResolvedImportPath = _origResolvedImportPath;
+
+            if (Directory.Exists(_tempDir))
+            {
+                try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        public void Vb365dir_NotImporting_JoinsUnsafeDirAndVb365DirViaPathCombine()
+        {
+            string expected = Path.Combine(_tempDir, "Original", "VB365");
+
+            Assert.Equal(expected, CVariables.vb365dir);
+        }
+
+        [Fact]
+        public void VbrDir_NotImporting_StartsWithUnsafeDirAndVbrDirJoinedViaPathCombine()
+        {
+            string expectedBase = Path.Combine(_tempDir, "Original", "VBR");
+
+            // Not an exact match: GetVbrDirWithTimestamp() appends server name and run
+            // timestamp segments after the base.
+            Assert.StartsWith(expectedBase, CVariables.vbrDir);
+        }
+
+        [Fact]
+        public void GetVbrBaseDir_NotImporting_EqualsUnsafeDirAndVbrDirJoinedViaPathCombine()
+        {
+            string expected = Path.Combine(_tempDir, "Original", "VBR");
+
+            Assert.Equal(expected, CVariables.GetVbrBaseDir());
+        }
+    }
+}

--- a/vHC/VhcXTests/VhcXTests.csproj
+++ b/vHC/VhcXTests/VhcXTests.csproj
@@ -12,13 +12,9 @@
     
     <!-- Suppress code analysis warnings - revisit later -->
     <NoWarn>CA1305,CA1307,CA1820,CA2242,CA1031,CA1806,CA1822</NoWarn>
-    
-    <!-- Skip compilation on non-Windows platforms -->
-    <EnableDefaultCompileItems Condition="!$([MSBuild]::IsOSPlatform('Windows'))">false</EnableDefaultCompileItems>
   </PropertyGroup>
 
-  <!-- Only include packages on Windows -->
-  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
@@ -29,13 +25,8 @@
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+  <ItemGroup>
     <ProjectReference Include="..\HC_Reporting\VeeamHealthCheck.csproj" />
   </ItemGroup>
-  
-  <!-- Display message when building on non-Windows -->
-  <Target Name="ShowNonWindowsMessage" BeforeTargets="CoreCompile" Condition="!$([MSBuild]::IsOSPlatform('Windows'))">
-    <Message Text="⚠️  Skipping VhcXTests compilation on non-Windows platform (tests require Windows/.NET WPF)" Importance="high" />
-  </Target>
 
 </Project>

--- a/vHC/VhcXTests/WindowsOnlyFactAttribute.cs
+++ b/vHC/VhcXTests/WindowsOnlyFactAttribute.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2021, Adam Congdon <adam.congdon2@gmail.com>
+// MIT License
+using System;
+using Xunit;
+
+namespace VhcXTests
+{
+    /// <summary>
+    /// Marks a test that exercises behavior with no cross-platform equivalent (DPAPI,
+    /// Windows ACLs, the registry, ...) so it reports as Skipped rather than Failed when
+    /// the suite runs on macOS/Linux. xUnit reads Skip off the attribute instance after
+    /// construction, so it can be set conditionally here rather than needing to be a
+    /// compile-time constant.
+    /// </summary>
+    public sealed class WindowsOnlyFactAttribute : FactAttribute
+    {
+        public WindowsOnlyFactAttribute()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                this.Skip = "Windows-only behavior (no cross-platform equivalent)";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-on to #211 (WPF → Avalonia migration): finishes making the codebase actually buildable and testable on macOS/Linux, and fixes real cross-platform path bugs surfaced along the way.

- **Startup cross-platform safety** — `CAdminCheck.IsAdmin()` moved off `WindowsIdentity`/`WindowsPrincipal` (which throws `PlatformNotSupportedException` off Windows) to `Environment.IsPrivilegedProcess` so it no longer crashes non-Windows builds/tests. (Follow-up work below made this OS-conditional instead, since the two aren't guaranteed equivalent on Windows in all token states.) `CArgsParser.Handle()`'s console-handle P/Invoke and `CredentialStore`'s DPAPI calls are guarded with `OperatingSystem.IsWindows()` since neither has a cross-platform equivalent; `CredentialStore` never falls back to writing unencrypted bytes on non-Windows — persistent storage becomes a session-only no-op there instead.
- **Unblock `VhcXTests` on macOS/Linux** — `VhcXTests.csproj` gated its package refs, project ref, and compilation itself behind `IsOSPlatform('Windows')`, reporting a false "0 errors" on non-Windows while silently compiling nothing. Relaxed all three gates now that `VeeamHealthCheck.csproj` builds cross-platform post-Avalonia. Added `WindowsOnlyFactAttribute` so the genuinely Windows-only tests (DPAPI, ACLs, registry, Windows path-char validation) report Skipped rather than Failed off Windows.
- **Real path-building bugs** — `CHtmlExporter`, `CCsvParser.ExtractServerNameFromCsvFileName`, `PSScriptIntegrationTests`, and `IndividualJobSessionsHelper` (`CleanFolder`/`SetMainDir`/`SetScrubDir`) all built paths via raw string concatenation with hardcoded `\` literals, which only produces a real nested directory on Windows — elsewhere it collapses into a single oddly-named folder/file. Fixed via `Path.Combine`/separator-agnostic parsing, including a shared `BuildReportDir` helper for the job-sessions case (later extracted further, see below).
- Documented (not changed) the two hardcoded `@"C:\temp\vHC"` defaults (`CVariables.outDir`, `CArgsParser`'s local `targetDir`): actual collection depends on the Windows-only `Veeam.Backup.PowerShell` module regardless of `REMOTEEXEC`, so the compiled binary only ever runs on Windows for now — a Windows-only default output path isn't in tension with "compile and test cross-platform" the way the path-concatenation bugs were.

## Follow-up fixes (post-review)

An `xhigh` code review of this branch found a few real bugs, plus some findings that only mattered once the goal was reframed: **the compiled tool only ever runs on Windows in production (Veeam PowerShell module dependency) — the cross-platform work here is entirely about making `dotnet build`/`dotnet test` trustworthy on non-Windows CI/dev machines, not about shipping the tool cross-platform.** That's why some of these are fixes to test/build correctness rather than anything a real user would ever hit:

- **`CredentialStore.Remove()`** didn't rewrite `creds.json` on non-Windows when other credentials remained, so a removed credential could silently reappear on next start. Now edits the on-disk file's own dict directly instead of re-serializing the in-memory cache.
- **`SanitizeFileName`/`Path.Combine` rooted-path escape** — a VBR job name like `"C: Nightly Backup"` made `Path.Combine` silently discard the report output directory, reproducing on Windows itself (not just cross-platform). Fixed by also stripping `:`.
- **`CAdminCheck.IsAdmin()`** reverted to `WindowsPrincipal.IsInRole(Administrator)` on Windows (matching the original pre-#211 behavior exactly, sidestepping a disputed equivalence with `Environment.IsPrivilegedProcess` in some token states), keeping `Environment.IsPrivilegedProcess` as the non-Windows fallback so builds/tests still don't crash off Windows.
- **`CredentialStore.SetTransient()`/`Set()` cache leak** — a `/credfile=`-loaded transient credential could get persisted to disk by an unrelated `Set()` call for a different host later in the same process, violating `SetTransient`'s "never written to disk" contract. Fixed with a transient-key tracker and a disk-merge (not overwrite) strategy, so it can't regress into losing already-persisted credentials either.
- **`CVariables` raw `+` concatenation** (`vb365dir`, `GetVbrDirWithTimestamp`, `GetVbrBaseDir`) — never breaks on real Windows, but breaks the moment tests exercise it on non-Windows CI. Extracted a shared `CCrossPlatformPath.Combine` helper and used it here and in `CHtmlExporter`/`IndividualJobSessionsHelper`, deduping the "TrimStart then Path.Combine" idiom that had been reinvented twice.
- **`CredentialStoreSecurityTests`** hit the real `%APPDATA%/VeeamHealthCheck/creds.json` instead of an isolated temp path. Added an `internal` settable `CredentialStore.StorePath` seam so the whole suite is isolated from a real user's stored credentials.
- Hoisted redundant per-job-session-group `Directory.Exists`/`CreateDirectory` calls in `IndividualJobSessionsHelper` out of the report-generation loop.
- Fixed a wrong-variable log line in `CArgsParser`'s `/path=`/`/PATH=` handling (logged `targetDir` instead of the parsed `_hfdPath`), and collapsed the two duplicate cases into one case-insensitive match.
- Updated `CLAUDE.md`'s stale "tests require Windows" claims and documented `EnableWindowsTargeting`/the second `VhcXTests.CrossPlatform` test project.

Result: 839 tests — 839 passed, 0 skipped, 0 failed on Windows CI and on a real Windows machine; 827 passed / 12 skipped (Windows-only tests correctly skip) on macOS.

## Test plan

- [x] `dotnet test vHC/VhcXTests/VhcXTests.csproj` passes on macOS (827 passed, 12 skipped, 0 failed)
- [x] CI: full Windows build/test run (`test-same-repo-pr` on `windows-latest`, 839 passed, 0 skipped, 0 failed)
- [x] Full local test run on a real Windows machine (839 passed, 0 skipped, 0 failed)
- [x] Self-contained single-file `win-x64` publish built on Windows — ran a live VBR collection + report generation successfully
- [x] Self-contained single-file `win-x64` publish built on **macOS** (cross-compiled) — ran a live VBR collection + report generation successfully on the same Windows machine
