### PR TITLE
fix(nas): isolate per-stage export failures, close the untested-Pester gap

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - 'vHC/HC_Reporting/Functions/Collection/PSCollections/Scripts/TestMfa.ps1'
       - 'vHC/HC_Reporting/Functions/Collection/PSCollections/Scripts/TestMfa.Tests.ps1'
+      - 'vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1'
+      - 'vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1'
   pull_request:
     branches: [master, dev]
     paths:
       - 'vHC/HC_Reporting/Functions/Collection/PSCollections/Scripts/TestMfa.ps1'
       - 'vHC/HC_Reporting/Functions/Collection/PSCollections/Scripts/TestMfa.Tests.ps1'
+      - 'vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1'
+      - 'vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1'
   workflow_dispatch:
 
 jobs:
@@ -109,6 +113,90 @@ jobs:
           | T11 | CorePath absent, Get-Package finds path |
 
           > Full NUnit XML results available in the **pester-results-${{ github.run_number }}** artifact.
+          "@
+
+          $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+
+  pester-nasinfo:
+    name: Pester — Get-NasInfo
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Ensure Pester v5 is available
+        shell: pwsh
+        run: |
+          $pester = Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge '5.0.0' } | Select-Object -First 1
+          if (-not $pester) {
+            Write-Host 'Pester v5 not found — installing from PSGallery...'
+            Install-Module -Name Pester -MinimumVersion 5.0.0 -Scope CurrentUser -Force -SkipPublisherCheck
+          } else {
+            Write-Host "Pester $($pester.Version) already available"
+          }
+
+      - name: Run Pester tests
+        id: pester_run
+        shell: pwsh
+        run: |
+          Import-Module Pester -MinimumVersion 5.0.0
+
+          $testFile = 'vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1'
+          $resultsFile = 'pester-nasinfo-results.xml'
+
+          $config = New-PesterConfiguration
+          $config.Run.Path = $testFile
+          $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputFormat = 'NUnitXml'
+          $config.TestResult.OutputPath = $resultsFile
+
+          $result = Invoke-Pester -Configuration $config
+
+          # Surface counts for summary step
+          "passed=$($result.PassedCount)"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "failed=$($result.FailedCount)"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "skipped=$($result.SkippedCount)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "total=$($result.TotalCount)"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+          if ($result.FailedCount -gt 0) {
+            Write-Host "::error::$($result.FailedCount) Pester test(s) failed"
+            exit 1
+          }
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pester-nasinfo-results-${{ github.run_number }}
+          path: pester-nasinfo-results.xml
+          retention-days: 30
+
+      - name: Write job summary
+        if: always()
+        shell: pwsh
+        run: |
+          $passed  = '${{ steps.pester_run.outputs.passed }}'
+          $failed  = '${{ steps.pester_run.outputs.failed }}'
+          $skipped = '${{ steps.pester_run.outputs.skipped }}'
+          $total   = '${{ steps.pester_run.outputs.total }}'
+
+          $status = if ($failed -eq '0') { ':white_check_mark: All tests passed' } else { ":x: $failed test(s) failed" }
+
+          $summary = @"
+          ## Pester Test Results — Get-NasInfo
+
+          **$status**
+
+          | Passed | Failed | Skipped | Total |
+          |--------|--------|---------|-------|
+          | $passed | $failed | $skipped | $total |
+
+          ### Test File
+          ``vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1``
+
+          > Full NUnit XML results available in the **pester-nasinfo-results-${{ github.run_number }}** artifact.
           "@
 
           $summary | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
@@ -613,7 +613,7 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             }
 
             // Add LogPath parameter so collector logs follow the configured output root
-            argString += $"-LogPath \"{Path.Combine(CVariables.unsafeDir, "Log")}\" ";
+            argString += $"-LogPath \"{CollectorLogPath()}\" ";
             // Add credentials if needed for remote execution
             string safeArgString = argString; // For logging without sensitive data
             if (needsCredentials)
@@ -659,6 +659,10 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
                 RedirectStandardError = true
             };
         }
+
+        // CVariables.unsafeDir is Path.Combine(CGlobals.desiredPath ?? outDir, "Original"),
+        // where outDir is a hardcoded non-empty constant - it can never be null or empty.
+        private static string CollectorLogPath() => Path.Combine(CVariables.unsafeDir, "Log");
 
         private ProcessStartInfo VbrNasStartInfo()
         {
@@ -816,12 +820,9 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
                 }
                 // Add LogPath so this phase (e.g. Get-NasInfo) writes its own log next to the
                 // configured output root instead of running silently. Mirrors VbrConfigStartInfo.
-                if (!string.IsNullOrEmpty(CVariables.unsafeDir))
-                {
-                    string nasLogPath = Path.Combine(CVariables.unsafeDir, "Log");
-                    argString += $"-LogPath \"{nasLogPath}\" ";
-                    safeArgString += $"-LogPath \"{nasLogPath}\" ";
-                }
+                string nasLogPath = CollectorLogPath();
+                argString += $"-LogPath \"{nasLogPath}\" ";
+                safeArgString += $"-LogPath \"{nasLogPath}\" ";
                 if (needsCredentials)
                 {
                     CredsHandler ch = new();

--- a/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
+++ b/vHC/HC_Reporting/Functions/Collection/PSCollections/PSInvoker.cs
@@ -501,6 +501,21 @@ namespace VeeamHealthCheck.Functions.Collection.PSCollections
             if (!string.IsNullOrWhiteSpace(stdOut))
             {
                 this.log.Debug($"[PS][STDOUT] {stdOut}", false);
+
+                // Get-NasInfo.ps1 deliberately never fails the whole run over a NAS-only
+                // problem (it's supplementary data) - its own catch blocks log via
+                // Write-NasLog and let the script exit 0. Without this, that failure is only
+                // visible in the Debug-only dump above (or a separate log file nobody opens),
+                // so a partial NAS data gap looks like a clean, complete run. Promote it to a
+                // Warning in the main log without touching `failed` - the script's own "don't
+                // abort the run" decision stands.
+                foreach (string outLine in stdOut.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (outLine.Contains("[Get-NasInfo]") && outLine.Contains("[ERROR]"))
+                    {
+                        this.log.Warning(outLine, false);
+                    }
+                }
             }
 
             // Process stderr

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.Tests.ps1
@@ -70,9 +70,92 @@ Describe 'Get-NasInfo VMC.log existence guard' {
 
             $csv = Join-Path $script:TempPath 'TESTSRV_NasFileData.csv'
             (Test-Path -LiteralPath $csv) | Should -BeTrue
-            # Wrap in @() because Get-Content returns a scalar for single-line files in PS 5.x and 7.x;
-            # require header + at least one data row, not just header.
-            @(Get-Content -LiteralPath $csv).Count | Should -BeGreaterThan 1
+            # Import-Csv instead of Get-Content: the Get-Content mock above has no filter-less
+            # fallback and would error on this call. Require at least one data row, not just
+            # a header with zero rows.
+            @(Import-Csv -LiteralPath $csv).Count | Should -BeGreaterThan 0
+        }
+    }
+}
+
+Describe 'Get-NasInfo per-stage failure isolation (#210)' {
+
+    BeforeEach {
+        $script:TempPath = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString())
+        New-Item -Path $script:TempPath -ItemType Directory -Force | Out-Null
+    }
+
+    AfterEach {
+        if (Test-Path -LiteralPath $script:TempPath) {
+            Remove-Item -LiteralPath $script:TempPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    Context 'one export stage fails' {
+
+        It 'still runs the later export stages and logs only the failing one' {
+            Mock Test-Path -MockWith { $true }
+
+            # Fixture populates all three export stages with at least one row each. This
+            # matters: an empty array piped into Export-Csv never actually invokes the
+            # downstream command (zero pipeline input means the process block never runs), so
+            # a mock covering an empty stage would never be exercised and this test would pass
+            # for the wrong reason.
+            $prefix = 'A' * 49
+            Mock Get-Content -MockWith {
+                @(
+                    ($prefix + '=====NAS INFRASTRUCTURE===='),
+                    ($prefix + 'TotalObjectStorageSize: Name: repo1, SizeGb: 5'),
+                    ($prefix + 'NasBackupSourceShareStats: Name: share1, SizeGb: 10'),
+                    ($prefix + 'TotalShareSize: FileShareID: fs1, SizeGb: 20'),
+                    ($prefix + '========')
+                )
+            } -ParameterFilter {
+                $LiteralPath -eq 'C:\ProgramData\Veeam\Backup\Utils\VMC.log'
+            }
+            Mock New-Item -MockWith { }
+            Mock Export-Csv -MockWith { }
+            # Write-Error (non-terminating by default) instead of throw: this is what a real
+            # Export-Csv failure (locked file, disk full) looks like, and only becomes fatal to
+            # this try block because the script sets $ErrorActionPreference = 'Stop'. Using
+            # throw here would pass even if that line were deleted.
+            Mock Export-Csv -MockWith { Write-Error 'Disk full' } -ParameterFilter {
+                $Path -like '*_NasObjectSourceStorageSize.csv'
+            }
+
+            { & $script:ScriptPath -VBRServer 'TESTSRV' -VBRVersion 12 -ReportPath $script:TempPath } |
+                Should -Not -Throw
+
+            # All three export stages are still attempted despite the first one failing.
+            Should -Invoke Export-Csv -Times 3 -Exactly
+
+            $logFile = Join-Path $script:TempPath 'CollectorNasInfo.log'
+            $logText = [System.IO.File]::ReadAllText($logFile)
+            $logText | Should -Match '\[ERROR\] \[Get-NasInfo\] FAILED exporting NasObjectSourceStorageSize\.csv'
+            $logText | Should -Match 'Exported 1 row\(s\) to TESTSRV_NasFileData\.csv'
+            $logText | Should -Match 'Exported 1 row\(s\) to TESTSRV_NasSharesize\.csv'
+        }
+    }
+
+    Context 'a failure occurs before any export stage' {
+
+        It 'is caught by the outer handler, logged, and does not abort the script' {
+            Mock Test-Path -MockWith { $true }
+            Mock New-Item -MockWith { }
+            # Same rationale as above: non-terminating by default, promoted to fatal only by
+            # $ErrorActionPreference = 'Stop' inside the script's try block.
+            Mock Get-Content -MockWith { Write-Error 'Access to the path is denied' } -ParameterFilter {
+                $LiteralPath -eq 'C:\ProgramData\Veeam\Backup\Utils\VMC.log'
+            }
+
+            { & $script:ScriptPath -VBRServer 'TESTSRV' -VBRVersion 12 -ReportPath $script:TempPath } |
+                Should -Not -Throw
+
+            $logFile = Join-Path $script:TempPath 'CollectorNasInfo.log'
+            $logText = [System.IO.File]::ReadAllText($logFile)
+            $logText | Should -Match '\[ERROR\] \[Get-NasInfo\] FAILED: Access to the path is denied'
+            # finally block still runs even though the try block failed early.
+            $logText | Should -Match '\[INFO\] \[Get-NasInfo\] Completed in'
         }
     }
 }

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
@@ -37,11 +37,13 @@ function Protect-VhciCsvInjection {
     }
 }
 
-# Self-contained logger. This script runs as its own PowerShell process (launched by
-# PSInvoker), so it cannot use the vHC-VbrConfig module's Write-LogFile. Every line is
-# written to STDOUT (captured by the GUI as [PS][STDOUT]) and appended to its own log
-# file when a log directory is resolvable. This phase used to run completely silently,
-# which is why a slow or stuck VMC.log parse looked like the whole tool hanging.
+# Self-contained logger. This script is launched standalone by PSInvoker, without going
+# through Initialize-VhcModule (VBR-Orchestrator's setup step for the vHC-VbrConfig
+# module's Write-LogFile), so it can't call that function here. Every line is written to
+# STDOUT (captured by the GUI as [PS][STDOUT]) and appended to its own log file - named to
+# match the CollectorX.log family other phases write - when a log directory is resolvable.
+# This phase used to run completely silently, which is why a slow or stuck VMC.log parse
+# looked like the whole tool hanging.
 $script:NasLogFile = $null
 function Write-NasLog {
     param([string]$Message, [string]$Level = 'INFO')
@@ -63,7 +65,7 @@ if ([string]::IsNullOrEmpty($ReportPath)) {
 if ([string]::IsNullOrEmpty($LogPath)) { $LogPath = $ReportPath }
 try {
     if (-not (Test-Path -LiteralPath $LogPath)) { New-Item -Path $LogPath -ItemType Directory -Force | Out-Null }
-    $script:NasLogFile = Join-Path $LogPath "Get-NasInfo.log"
+    $script:NasLogFile = Join-Path $LogPath "CollectorNasInfo.log"
 } catch {
     $script:NasLogFile = $null
 }

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
@@ -93,10 +93,12 @@ try {
         $readSw = [System.Diagnostics.Stopwatch]::StartNew()
         $content = Get-Content -LiteralPath $logsPath
         $readSw.Stop()
-        Write-NasLog ("Read {0} line(s) in {1:N1}s" -f @($content).Count, ($readSw.Elapsed.TotalSeconds))
+        $contentCount = @($content).Count
+        Write-NasLog ("Read {0} line(s) in {1:N1}s" -f $contentCount, ($readSw.Elapsed.TotalSeconds))
     } else {
         Write-NasLog "VMC.log not found at $logsPath - skipping unstructured/NAS section parsing" 'WARNING'
         $content = @()
+        $contentCount = 0
     }
 
     $sections = @()
@@ -107,7 +109,7 @@ try {
     foreach($line in $content){
         $lineNum++
         if (($lineNum % 200000) -eq 0) {
-            Write-NasLog ("Scanning VMC.log... {0}/{1} lines, {2} section(s) captured" -f $lineNum, @($content).Count, $sections.Count)
+            Write-NasLog ("Scanning VMC.log... {0}/{1} lines, {2} section(s) captured" -f $lineNum, $contentCount, $sections.Count)
         }
         if(-not $capturing -and $line -match $unstrucStart){
             $capturing = $true

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
@@ -184,61 +184,80 @@ try {
         return $props
     }
 
-    $csvData = @($totalObjectStorageSize | ForEach-Object { [PSCustomObject](ConvertTo-LogProperties $_) })
+    # Ensure the output directory exists before any of the three export stages below, so a
+    # directory-creation failure is attributed correctly instead of looking like a
+    # NasObjectSourceStorageSize-specific failure.
     if (!(Test-Path $ReportPath)) { New-Item -Path $ReportPath -ItemType Directory -Force | Out-Null }
-    $csvData | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasObjectSourceStorageSize.csv" -NoTypeInformation
-    Write-NasLog ("Exported {0} row(s) to {1}_NasObjectSourceStorageSize.csv" -f $csvData.Count, $VBRServer)
 
-    $csvData2 = @($nasBackupSourceShareStats | ForEach-Object { [PSCustomObject](ConvertTo-LogProperties $_) })
-    $csvData2 | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasFileData.csv" -NoTypeInformation
-    Write-NasLog ("Exported {0} row(s) to {1}_NasFileData.csv" -f $csvData2.Count, $VBRServer)
-
-    # Parse v12 combined lines
-    $v12Rows = @($totalShareSize | ForEach-Object {
-        $props = ConvertTo-LogProperties $_
-        if (-not $props.ContainsKey('ParentServerID')) { $props['ParentServerID'] = $null }
-        [PSCustomObject]$props
-    })
-
-    # Parse v13 parent lines into a hashtable keyed by FileShareID
-    $parentMap = @{}
-    $parentShares | ForEach-Object {
-        $props = ConvertTo-LogProperties $_
-        if ($props.ContainsKey('FileShareID')) {
-            $parentMap[$props['FileShareID']] = $props
-        }
+    # Each export stage below gets its own try/catch: NAS info is supplementary, so a failure
+    # partway through (locked file, disk full, permissions) must not cascade and silently skip
+    # every stage after it - only the stage that actually failed should end up missing its CSV.
+    try {
+        $csvData = @($totalObjectStorageSize | ForEach-Object { [PSCustomObject](ConvertTo-LogProperties $_) })
+        $csvData | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasObjectSourceStorageSize.csv" -NoTypeInformation
+        Write-NasLog ("Exported {0} row(s) to {1}_NasObjectSourceStorageSize.csv" -f $csvData.Count, $VBRServer)
+    } catch {
+        Write-NasLog "FAILED exporting NasObjectSourceStorageSize.csv: $($_.Exception.Message)" 'ERROR'
     }
 
-    # Parse v13 child lines and join with parent
-    $v13Rows = @($childShares | ForEach-Object {
-        $childProps = ConvertTo-LogProperties $_
-        $merged = @{}
+    try {
+        $csvData2 = @($nasBackupSourceShareStats | ForEach-Object { [PSCustomObject](ConvertTo-LogProperties $_) })
+        $csvData2 | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasFileData.csv" -NoTypeInformation
+        Write-NasLog ("Exported {0} row(s) to {1}_NasFileData.csv" -f $csvData2.Count, $VBRServer)
+    } catch {
+        Write-NasLog "FAILED exporting NasFileData.csv: $($_.Exception.Message)" 'ERROR'
+    }
 
-        # Start with parent properties (if parent found)
-        $parentId = $childProps['ParentServerID']
-        if ($parentId -and $parentMap.ContainsKey($parentId)) {
-            foreach ($key in $parentMap[$parentId].Keys) {
-                $merged[$key] = $parentMap[$parentId][$key]
+    try {
+        # Parse v12 combined lines
+        $v12Rows = @($totalShareSize | ForEach-Object {
+            $props = ConvertTo-LogProperties $_
+            if (-not $props.ContainsKey('ParentServerID')) { $props['ParentServerID'] = $null }
+            [PSCustomObject]$props
+        })
+
+        # Parse v13 parent lines into a hashtable keyed by FileShareID
+        $parentMap = @{}
+        $parentShares | ForEach-Object {
+            $props = ConvertTo-LogProperties $_
+            if ($props.ContainsKey('FileShareID')) {
+                $parentMap[$props['FileShareID']] = $props
             }
         }
 
-        # Overlay child properties (child wins on conflict)
-        foreach ($key in $childProps.Keys) {
-            $merged[$key] = $childProps[$key]
-        }
+        # Parse v13 child lines and join with parent
+        $v13Rows = @($childShares | ForEach-Object {
+            $childProps = ConvertTo-LogProperties $_
+            $merged = @{}
 
-        # Ensure ParentServerID always present
-        if (-not $merged.ContainsKey('ParentServerID')) { $merged['ParentServerID'] = $null }
-        [PSCustomObject]$merged
-    })
+            # Start with parent properties (if parent found)
+            $parentId = $childProps['ParentServerID']
+            if ($parentId -and $parentMap.ContainsKey($parentId)) {
+                foreach ($key in $parentMap[$parentId].Keys) {
+                    $merged[$key] = $parentMap[$parentId][$key]
+                }
+            }
 
-    # Union v12 and v13 rows; v13 rows first so the header reflects the full v13 schema
-    $allShareRows = @()
-    if ($v13Rows.Count -gt 0) { $allShareRows += $v13Rows }
-    if ($v12Rows.Count -gt 0) { $allShareRows += $v12Rows }
+            # Overlay child properties (child wins on conflict)
+            foreach ($key in $childProps.Keys) {
+                $merged[$key] = $childProps[$key]
+            }
 
-    $allShareRows | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasSharesize.csv" -NoTypeInformation
-    Write-NasLog ("Exported {0} row(s) to {1}_NasSharesize.csv ({2} v13 + {3} v12)" -f $allShareRows.Count, $VBRServer, $v13Rows.Count, $v12Rows.Count)
+            # Ensure ParentServerID always present
+            if (-not $merged.ContainsKey('ParentServerID')) { $merged['ParentServerID'] = $null }
+            [PSCustomObject]$merged
+        })
+
+        # Union v12 and v13 rows; v13 rows first so the header reflects the full v13 schema
+        $allShareRows = @()
+        if ($v13Rows.Count -gt 0) { $allShareRows += $v13Rows }
+        if ($v12Rows.Count -gt 0) { $allShareRows += $v12Rows }
+
+        $allShareRows | Protect-VhciCsvInjection | Export-Csv -Path "$ReportPath\${VBRServer}_NasSharesize.csv" -NoTypeInformation
+        Write-NasLog ("Exported {0} row(s) to {1}_NasSharesize.csv ({2} v13 + {3} v12)" -f $allShareRows.Count, $VBRServer, $v13Rows.Count, $v12Rows.Count)
+    } catch {
+        Write-NasLog "FAILED exporting NasSharesize.csv: $($_.Exception.Message)" 'ERROR'
+    }
 }
 catch {
     # Deliberately not re-thrown: PSInvoker treats a non-zero exit from this script as a

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
@@ -74,6 +74,10 @@ $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 Write-NasLog "Starting. VBRServer=$VBRServer VBRVersion=$VBRVersion ReportPath=$ReportPath PS=$($PSVersionTable.PSVersion)"
 
 try {
+    # Without this, most cmdlet failures below (Get-Content, Export-Csv, New-Item, ...) are
+    # non-terminating and silently skip past the catch block, defeating the point of having one.
+    $ErrorActionPreference = 'Stop'
+
     # VMC log path is hardcoded for now. If logs are sent elsewhere, please adjust accordingly.
     $logsPath = "C:\ProgramData\Veeam\Backup\Utils\VMC.log"
 
@@ -237,9 +241,13 @@ try {
     Write-NasLog ("Exported {0} row(s) to {1}_NasSharesize.csv ({2} v13 + {3} v12)" -f $allShareRows.Count, $VBRServer, $v13Rows.Count, $v12Rows.Count)
 }
 catch {
+    # Deliberately not re-thrown: PSInvoker treats a non-zero exit from this script as a
+    # collection failure and aborts the whole run (unlike the VBR config phase, which
+    # tolerates a bad exit code when its manifest is already on disk). NAS info is
+    # supplementary - log the failure loudly and let the script finish normally so a NAS-only
+    # problem can't take down report generation for everything else.
     Write-NasLog "FAILED: $($_.Exception.Message)" 'ERROR'
     Write-NasLog "$($_.ScriptStackTrace)" 'ERROR'
-    throw
 }
 finally {
     $stopwatch.Stop()

--- a/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
+++ b/vHC/HC_Reporting/Tools/Scripts/HealthCheck/VBR/Get-NasInfo.ps1
@@ -96,7 +96,6 @@ try {
         Write-NasLog ("Read {0} line(s) in {1:N1}s" -f @($content).Count, ($readSw.Elapsed.TotalSeconds))
     } else {
         Write-NasLog "VMC.log not found at $logsPath - skipping unstructured/NAS section parsing" 'WARNING'
-        Write-Verbose "VMC.log not found at $logsPath - skipping unstructured/NAS section parsing"
         $content = @()
     }
 


### PR DESCRIPTION
## Summary

Split out of #210 — these changes touch `Get-NasInfo.ps1`/`PSInvoker.cs` only, and are unrelated to the VB365 VMC.log crash #210 fixes. They build directly on #208 (merged into `dev`), which added logging to `Get-NasInfo.ps1` but used non-terminating error handling, so a mid-script `Export-Csv` failure would silently skip past the `catch` block and exit 0.

- `$ErrorActionPreference = 'Stop'` inside the script's try block, so cmdlet failures actually reach `catch` instead of passing through silently.
- Each of the three CSV export stages gets its own try/catch, so one failing stage (locked file, disk full, permissions) doesn't skip the remaining stages.
- `PSInvoker.cs` promotes `[Get-NasInfo][ERROR]` stdout lines to a main-log `Warning` without touching `failed`, so a partial NAS failure is visible without aborting the run.
- Minor cleanup: dedup'd `-LogPath` construction into `CollectorLogPath()`, renamed the log file to match the `CollectorX.log` family, cached a repeated `@($content).Count`.

## Also fixes a CI gap

`Get-NasInfo.Tests.ps1` existed (from #208) but `pester-tests.yml`'s path filter only ever triggered on `TestMfa.ps1`/`TestMfa.Tests.ps1` — this file has never actually run in CI. Running it locally surfaced a real bug: the ISC-5 test's own verification step called the mocked `Get-Content` with no matching filter and no default fallback, so it errored rather than asserting anything.

- Fixed that mock gap (switched the verification to `Import-Csv`, which isn't mocked).
- Added two new regression tests for the per-stage isolation and outer-catch behavior above. Both use `Write-Error` (not `throw`) inside the mocks and were empirically verified to go **red** with `$ErrorActionPreference = 'Stop'` removed, so they test the actual mechanism, not just script structure.
- Added `Get-NasInfo.ps1`/`Get-NasInfo.Tests.ps1` to `pester-tests.yml`'s path filter and a new `pester-nasinfo` job so this suite actually runs going forward.

## Verification

- All 4 Pester tests (2 existing + 2 new) pass locally via `pwsh`/Pester 6.1.0.
- Confirmed both new tests fail (red) when `$ErrorActionPreference = 'Stop'` is removed, confirming they're genuine regression tests.
- `.github/workflows/pester-tests.yml` YAML validated to parse correctly.

## Test plan

- [ ] CI `pester-nasinfo` job green on windows-latest
- [ ] CI `pester` (TestMfa) job unaffected